### PR TITLE
use workflow.source_path for extra_functionality script and as `param`

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -82,10 +82,6 @@ rule modify_cost_data:
 
 
 use rule solve_sector_network_myopic from pypsaeur with:
-    input:
-        network=RESULTS
-        + "prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
-        costs="data/costs_{planning_horizons}.csv",
-        config=RESULTS + "config.yaml",
-        additional_functionality="workflow/scripts/additional_functionality.py",
-        co2_totals_name=RESOURCES + "co2_totals.csv",
+    params:
+        **rules.solve_sector_network_myopic.params,
+        additional_functionality=workflow.source_path("scripts/additional_functionality.py"),


### PR DESCRIPTION
This saves adding the source path in `solve_network.py`.

It also reuses params definitions `rules.<rulename>.params`.

Together with https://github.com/PyPSA/pypsa-eur/pull/823