### PR TITLE
Improve environment.yaml

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -52,7 +52,7 @@ dependencies:
 - pypsa>=0.25.1
 - highs
 - linopy<=0.2.6
-
+- pyam
 
   # Keep in conda environment when calling ipython
 - ipython

--- a/environment.yaml
+++ b/environment.yaml
@@ -48,6 +48,10 @@ dependencies:
 - tabula-py
 - pyxlsb
 - graphviz
+- tsam>=1.1.0
+- pypsa>=0.25.1
+- highs
+
 
   # Keep in conda environment when calling ipython
 - ipython
@@ -58,7 +62,4 @@ dependencies:
 - rasterio!=1.2.10
 
 
-- pip:
-  - tsam>=1.1.0
-  - pypsa>=0.25.1
-  - highspy
+

--- a/environment.yaml
+++ b/environment.yaml
@@ -29,7 +29,7 @@ dependencies:
 - geopandas>=0.11.0
 - atlite>=0.2.9
 - dask
-- xarray<=2023.8.0
+- xarray
 - rioxarray
 - netcdf4
 - networkx

--- a/environment.yaml
+++ b/environment.yaml
@@ -51,7 +51,6 @@ dependencies:
 - tsam>=1.1.0
 - pypsa>=0.25.1
 - highs
-- linopy
 - pyam
 
   # Keep in conda environment when calling ipython

--- a/environment.yaml
+++ b/environment.yaml
@@ -51,7 +51,7 @@ dependencies:
 - tsam>=1.1.0
 - pypsa>=0.25.1
 - highs
-- linopy<=0.2.6
+- linopy
 - pyam
 
   # Keep in conda environment when calling ipython

--- a/environment.yaml
+++ b/environment.yaml
@@ -51,6 +51,7 @@ dependencies:
 - tsam>=1.1.0
 - pypsa>=0.25.1
 - highs
+- linopy<=0.2.6
 
 
   # Keep in conda environment when calling ipython


### PR DESCRIPTION
When using several conda environments with the same Python version a strange behaviour may occur: The packages installed via pip are only visible from the environment in which they were first installed. All other environments use these pip-installed packages, but do not list them (via `conda list`). As a consequence its hard to figure out which packages are actually used and in what version. Since all packages used by this repo are available via conda-forge, it would be cleaner not to use pip.

Additionally, restricting linopy <= 0.2.6 fixed a strange bug in solve_network. Apparently @fneum suggested this.