### PR TITLE
non-CO2 GHG correction for national CO2 targets

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -75,14 +75,15 @@ co2_budget:
   2050: 0.000 # climate-neutral by 2050
 
 co2_budget_national:
+  # Corrected for non-CO2 GHGs via the ariadne database
   2020:
-    DE: 0.6
+    DE: 0.58 # 0.6
   2030:
-    DE: 0.35
+    DE: 0.30 # 0.35
   2040:
-    DE: 0.12
+    DE: 0.09 # 0.12
   2050:
-    DE: 0.
+    DE: -0.04 # 0.
 
 limits_min:
   Generator:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -75,15 +75,20 @@ co2_budget:
   2050: 0.000 # climate-neutral by 2050
 
 co2_budget_national:
-  # Corrected for non-CO2 GHGs via the ariadne database
   2020:
-    DE: 0.73 # 0.6
+    DE: 0.73
+  2025:
+    DE: 0.57
   2030:
-    DE: 0.40 # 0.35
+    DE: 0.4
+  2035:
+    DE: 0.26
   2040:
-    DE: 0.12 # 0.12
+    DE: 0.12
+  2045:
+    DE: -0.03
   2050:
-    DE: -0.02 # 0.
+    DE: -0.02
 
 limits_min:
   Generator:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -76,19 +76,19 @@ co2_budget:
 
 co2_budget_national:
   2020:
-    DE: 0.73
+    DE: 0.728
   2025:
-    DE: 0.57
+    DE: 0.571
   2030:
-    DE: 0.4
+    DE: 0.396
   2035:
-    DE: 0.26
+    DE: 0.258
   2040:
-    DE: 0.12
+    DE: 0.118
   2045:
-    DE: -0.03
+    DE: -0.028
   2050:
-    DE: -0.02
+    DE: -0.024
 
 limits_min:
   Generator:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -77,13 +77,13 @@ co2_budget:
 co2_budget_national:
   # Corrected for non-CO2 GHGs via the ariadne database
   2020:
-    DE: 0.58 # 0.6
+    DE: 0.73 # 0.6
   2030:
-    DE: 0.30 # 0.35
+    DE: 0.40 # 0.35
   2040:
-    DE: 0.09 # 0.12
+    DE: 0.12 # 0.12
   2050:
-    DE: -0.04 # 0.
+    DE: -0.02 # 0.
 
 limits_min:
   Generator:

--- a/workflow/scripts/_compute_co2_targets_DE.py
+++ b/workflow/scripts/_compute_co2_targets_DE.py
@@ -1,0 +1,64 @@
+import pyam
+import pandas as pd
+
+# Set USERNAME and PASSWORD for the Ariadne DB
+pyam.iiasa.set_config(USERNAME, PASSWORD)
+
+model_df= pyam.read_iiasa(
+    "ariadne_intern",
+    model="Hybrid",
+    scenario="8Gt_Bal_v3",
+).timeseries()
+
+df = model_df.loc["Hybrid", "8Gt_Bal_v3", "Deutschland"]
+
+baseline_ksg = 1251
+baseline_pypsa = 1052
+
+## GHG target according to KSG
+initial_years2030_ksg = pd.Series(
+    index = [2020, 2025, 2030],
+    data = [813, 643, 438],
+)
+
+later_years_ksg = pd.Series(
+    index = [2035, 2040, 2045, 2050],
+    data = [0.77, 0.88, 1.0, 1.0],
+)
+
+targets_ksg = pd.concat(
+    [initial_years2030_ksg, (1 - later_years_ksg) * baseline_ksg],
+)
+
+## Compute nonco2 from Ariadne-Hybrid model
+
+co2_ksg = (
+    df.loc["Emissions|CO2 incl Bunkers","Mt CO2/yr"]  
+    - df.loc["Emissions|CO2|Land-Use Change","Mt CO2-equiv/yr"]
+    - df.loc["Emissions|CO2|Energy|Demand|Bunkers","Mt CO2/yr"]
+)
+
+ghg_ksg = (
+    df.loc["Emissions|Kyoto Gases","Mt CO2-equiv/yr"]
+    - df.loc["Emissions|Kyoto Gases|Land-Use Change","Mt CO2-equiv/yr"]
+    # No Kyoto Gas emissions for Bunkers recorded in Ariadne DB
+)
+
+nonco2 = ghg_ksg - co2_ksg
+
+## PyPSA disregards nonco2 GHG emissions
+
+targets_pypsa = (
+    targets_ksg - nonco2 
+    + df.loc["Emissions|CO2|Energy|Demand|Bunkers","Mt CO2/yr"]
+)
+
+target_fractions_pypsa = (
+    targets_pypsa.loc[[2020, 2030, 2040, 2050]] / baseline_pypsa
+)
+
+print(
+    "PyPSA emission pathway for DE:\n", 
+    target_fractions_pypsa.round(2), 
+    sep="",
+)

--- a/workflow/scripts/_compute_co2_targets_DE.py
+++ b/workflow/scripts/_compute_co2_targets_DE.py
@@ -55,10 +55,10 @@ targets_pypsa = (
 
 target_fractions_pypsa = (
     targets_pypsa.loc[targets_ksg.index] / baseline_pypsa
-).round(2)
+)
 
 print("co2_budget_national:")
 
 for year in target_fractions_pypsa.index:
     print("  ", year, ":", sep="")
-    print("    DE:", target_fractions_pypsa[year] )
+    print("    DE:", target_fractions_pypsa[year].round(3))

--- a/workflow/scripts/_compute_co2_targets_DE.py
+++ b/workflow/scripts/_compute_co2_targets_DE.py
@@ -46,7 +46,7 @@ ghg_ksg = (
 
 nonco2 = ghg_ksg - co2_ksg
 
-## PyPSA disregards nonco2 GHG emissions
+## PyPSA disregards nonco2 GHG emissions, but includes bunkers
 
 targets_pypsa = (
     targets_ksg - nonco2 

--- a/workflow/scripts/_compute_co2_targets_DE.py
+++ b/workflow/scripts/_compute_co2_targets_DE.py
@@ -16,7 +16,7 @@ baseline_ksg = 1251
 baseline_pypsa = 1052
 
 ## GHG target according to KSG
-initial_years2030_ksg = pd.Series(
+initial_years_ksg = pd.Series(
     index = [2020, 2025, 2030],
     data = [813, 643, 438],
 )
@@ -27,7 +27,7 @@ later_years_ksg = pd.Series(
 )
 
 targets_ksg = pd.concat(
-    [initial_years2030_ksg, (1 - later_years_ksg) * baseline_ksg],
+    [initial_years_ksg, (1 - later_years_ksg) * baseline_ksg],
 )
 
 ## Compute nonco2 from Ariadne-Hybrid model

--- a/workflow/scripts/_compute_co2_targets_DE.py
+++ b/workflow/scripts/_compute_co2_targets_DE.py
@@ -54,7 +54,7 @@ targets_pypsa = (
 )
 
 target_fractions_pypsa = (
-    targets_pypsa.loc[[2020, 2030, 2040, 2050]] / baseline_pypsa
+    targets_pypsa.loc[targets_ksg.index] / baseline_pypsa
 )
 
 print(

--- a/workflow/scripts/_compute_co2_targets_DE.py
+++ b/workflow/scripts/_compute_co2_targets_DE.py
@@ -55,10 +55,10 @@ targets_pypsa = (
 
 target_fractions_pypsa = (
     targets_pypsa.loc[targets_ksg.index] / baseline_pypsa
-)
+).round(2)
 
-print(
-    "PyPSA emission pathway for DE:\n", 
-    target_fractions_pypsa.round(2), 
-    sep="",
-)
+print("co2_budget_national:")
+
+for year in target_fractions_pypsa.index:
+    print("  ", year, ":", sep="")
+    print("    DE:", target_fractions_pypsa[year] )


### PR DESCRIPTION
The Nationale Emissionsminderungsziele contain all Kyoto gases, Pypsa-eur models only CO2.

We take the non-CO2 Kyoto gases from the ariadne database, and subtract them from the targets. Interestingly this would lead to negative CO2 emissions targets for 2050 -> Does that make sense?

I did not consider any negative emissions from Land Use, Land Use Change and Afforestation yet (as these are not in the Ariadne database). However the KSG mentions negative sector targets for LULUCF. How should these be included? @nworbmot 

This is the script i used to compute the adjusted CO2 targets.

```python
import pyam
import numpy as np
import pandas as pd

pyam.iiasa.set_config(USERNAME, PASSWORD)

model_raw = pyam.read_iiasa("ariadne_intern",
                            model="Hybrid",
                            scenario="8Gt_EnSec")

model_df = model_raw.timeseries()

df = model_df.loc["Hybrid","8Gt_EnSec","Deutschland"]

target_years = [2020,2025,2030,2035,2040,2045,2050]

nonCO2Mt = df.loc["Emissions|Kyoto Gases","Mt CO2-equiv/yr"][target_years] - df.loc["Emissions|CO2 incl Bunkers","Mt CO2/yr"][target_years]

baseline1990 = 1251 # in Mt CO2-equiv
initial_years2025 = np.array([813, 643])
later_years = (1 - np.array([0.65, 0.77, 0.88, 1.0, 1.0])) * baseline1990

targetsMt = pd.Series(
    index=target_years, 
    data=np.append(initial_years2025 , later_years)
)

((targetsMt - nonCO2Mt) / baseline1990).round(2)
```