### PR TITLE
Resolve process emissions and co2 stores regionally

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -151,6 +151,7 @@ sector:
   min_part_load_fischer_tropsch: 0.
   regional_methanol_demand: true  #set to true if regional CO2 constraints needed
   regional_oil_demand: true  #set to true if regional CO2 constraints needed
+  co2_spatial: true #set to true if regional CO2 constraints needed
   biogas_upgrading_cc: true
   cluster_heat_buses: true
   # this needs to be taken from ariadne database


### PR DESCRIPTION
I had some issues when enabling `co2_spatial` for the first time, but now they are gone. Probably someone else should double check, before merging