### PR TITLE
adding commodity prices for coal, oil, gas from Ariadne assumptions

### DIFF
--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -1,4 +1,4 @@
 technology,parameter,value,unit,source,further description
 gas,fuel,11.2,EUR/MWh_th,Ariadne,
-oil,fuel,22.1982,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
-coal,fuel,5.7048,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"
+oil,fuel,22.1982,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,5.7048,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -1,2 +1,4 @@
 technology,parameter,value,unit,source,further description
-gas,fuel,50.0,EUR/MWh_th,TTF futures,
+gas,fuel,11.2,EUR/MWh_th,Ariadne,
+oil,fuel,22.1982,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
+coal,fuel,5.7048,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -1,4 +1,4 @@
 technology,parameter,value,unit,source,further description
 gas,fuel,40,EUR/MWh_th,Ariadne,
-oil,fuel,32.9876,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
-coal,fuel,10.6694,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"
+oil,fuel,32.9876,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,10.6694,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -1,0 +1,4 @@
+technology,parameter,value,unit,source,further description
+gas,fuel,40,EUR/MWh_th,Ariadne,
+oil,fuel,32.9876,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
+coal,fuel,10.6694,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -1,2 +1,4 @@
 technology,parameter,value,unit,source,further description
-gas,fuel,50.0,EUR/MWh_th,TTF futures,
+gas,fuel,22.3,EUR/MWh_th,Ariadne,
+oil,fuel,38.821,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
+coal,fuel,6.2056,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -1,4 +1,4 @@
 technology,parameter,value,unit,source,further description
 gas,fuel,22.3,EUR/MWh_th,Ariadne,
-oil,fuel,38.821,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
-coal,fuel,6.2056,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"
+oil,fuel,38.821,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,6.2056,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -1,0 +1,4 @@
+technology,parameter,value,unit,source,further description
+gas,fuel,22.4,EUR/MWh_th,Ariadne,
+oil,fuel,38.5629,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
+coal,fuel,6.2601,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -1,4 +1,4 @@
 technology,parameter,value,unit,source,further description
 gas,fuel,22.4,EUR/MWh_th,Ariadne,
-oil,fuel,38.5629,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
-coal,fuel,6.2601,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"
+oil,fuel,38.5629,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,6.2601,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -1,2 +1,4 @@
 technology,parameter,value,unit,source,further description
-gas,fuel,50.0,EUR/MWh_th,TTF futures,
+gas,fuel,22.6,EUR/MWh_th,Ariadne,
+oil,fuel,38.3564,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
+coal,fuel,6.3036,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -1,4 +1,4 @@
 technology,parameter,value,unit,source,further description
 gas,fuel,22.6,EUR/MWh_th,Ariadne,
-oil,fuel,38.3564,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
-coal,fuel,6.3036,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"
+oil,fuel,38.3564,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,6.3036,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -1,0 +1,4 @@
+technology,parameter,value,unit,source,further description
+gas,fuel,22.8,EUR/MWh_th,Ariadne,
+oil,fuel,38.0983,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
+coal,fuel,6.3472,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -1,4 +1,4 @@
 technology,parameter,value,unit,source,further description
 gas,fuel,22.8,EUR/MWh_th,Ariadne,
-oil,fuel,38.0983,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
-coal,fuel,6.3472,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"
+oil,fuel,38.0983,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,6.3472,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -1,4 +1,4 @@
 technology,parameter,value,unit,source,further description
 gas,fuel,22.9,EUR/MWh_th,Ariadne,
-oil,fuel,37.8918,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
-coal,fuel,6.4016,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"
+oil,fuel,37.8918,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,6.4016,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -1,2 +1,4 @@
 technology,parameter,value,unit,source,further description
-gas,fuel,50.0,EUR/MWh_th,TTF futures,
+gas,fuel,22.9,EUR/MWh_th,Ariadne,
+oil,fuel,37.8918,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1bbl = 1.6998MWh"
+coal,fuel,6.4016,EUR2020/Mwh,Ariadne,"$2020 = 0.8775 EUR, 1t = 8.06 Mwh"


### PR DESCRIPTION
# Adding Ariadne price assumptions for coal, gas and oil

Adding cost assumption from the initial price discussion of the [Ariadne Scenarios](https://docs.google.com/document/d/10V6o-1vPECYu5UiEi4alYS8r-CXqZSRKqJkAGKt1N0Y/edit) summarized in the [table](https://cloud.pik-potsdam.de/index.php/f/19528535).
For calculating prices in 2020Eur/MWh the following sources were taken:

- [Euro2020](https://www.bmz.de/de/ministerium/zahlen-fakten/oda-zahlen/hintergrund/dac-umrechnungskurs-35300)
- 1 bbl = 1.6998 MWh for Brent oil
- 1 t = 8.06 MWh for API2 coal

No values for biogas/-mass, lignite and nuclear