### PR TITLE
fix missing nuclear

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -23,7 +23,7 @@ dependencies:
 - yaml
 - pytables
 - lxml
-- powerplantmatching>=0.5.5
+- powerplantmatching>=0.5.11
 - numpy
 - pandas>=1.4
 - geopandas>=0.11.0


### PR DESCRIPTION
Include missing nuclear generation data as it was filtered out by powerplantmatching. Fixed in v0.5.11 in ppl. -> https://github.com/PyPSA/powerplantmatching