### PR TITLE
Fix nuclear

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  name: "240209-365H-fixcoalco2"
+  name: "test_nuclear"
   scenarios:
     enable: true
   shared_resources: true #stops recalculating
@@ -227,3 +227,23 @@ plotting:
   tech_colors:
     load: "#111100"
     H2 pipeline (Kernnetz): '#6b3161'
+
+# overwrite in config.default.yaml
+powerplants_filter: (DateOut >= 2020 or DateOut != DateOut)
+
+pypsa_eur:
+  Bus:
+  - AC
+  Link:
+  - DC
+  Generator:
+  - onwind
+  - offwind-ac
+  - offwind-dc
+  - solar
+  - ror
+  - nuclear
+  StorageUnit:
+  - PHS
+  - hydro
+  Store: []

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  name: "test_nuclear"
+  name: "240214-365H-test_nuclear"
   scenarios:
     enable: true
   shared_resources: true #stops recalculating
@@ -33,7 +33,7 @@ scenario:
   opts:
   - ''
   sector_opts:
-    - 365H-T-H-B-I-A
+    - 3H-T-H-B-I-A
   planning_horizons:
   - 2020
   - 2030
@@ -47,7 +47,7 @@ countries: ['AT', 'BE', 'CH', 'CZ', 'DE', 'DK', 'FR', 'GB', 'LU', 'NL', 'NO', 'P
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
 enable:
   retrieve: false # set to false once initial data is retrieved
-  retrieve_cutout: false # set to false once initial data is retrieved
+  retrieve_cutout: true # set to false once initial data is retrieved
 clustering:
   focus_weights:
   # 22 nodes: 8 for Germany, 2 each for Denmark and UK, 1 per each of other 10 "Stromnachbarn"
@@ -229,7 +229,7 @@ plotting:
     H2 pipeline (Kernnetz): '#6b3161'
 
 # overwrite in config.default.yaml
-powerplants_filter: (DateOut >= 2020 or DateOut != DateOut)
+powerplants_filter: (DateOut >= 2019 or DateOut != DateOut)
 
 pypsa_eur:
   Bus:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -242,7 +242,6 @@ pypsa_eur:
   - offwind-dc
   - solar
   - ror
-  - nuclear
   StorageUnit:
   - PHS
   - hydro

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,7 +33,7 @@ scenario:
   opts:
   - ''
   sector_opts:
-    - 3H-T-H-B-I-A
+    - 365H-T-H-B-I-A
   planning_horizons:
   - 2020
   - 2030
@@ -47,7 +47,7 @@ countries: ['AT', 'BE', 'CH', 'CZ', 'DE', 'DK', 'FR', 'GB', 'LU', 'NL', 'NO', 'P
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
 enable:
   retrieve: false # set to false once initial data is retrieved
-  retrieve_cutout: true # set to false once initial data is retrieved
+  retrieve_cutout: false # set to false once initial data is retrieved
 clustering:
   focus_weights:
   # 22 nodes: 8 for Germany, 2 each for Denmark and UK, 1 per each of other 10 "Stromnachbarn"


### PR DESCRIPTION
- overwrite config.default.yaml to include nuclear power plants in powerplantmatching
- model nuclear as links and exclude it from being a generator
- adapt query for powerplantmatching to include all plants that have a lifetime until 2019 or longer with DateOut argument