### PR TITLE
additional_funcitonality: improve numeric printout in logs

### DIFF
--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -103,7 +103,10 @@ def add_co2limit_country(n, limit_countries, snakemake):
 
     for ct in limit_countries:
         limit = co2_total_totals[ct]*limit_countries[ct]
-        logger.info(f"Limiting emissions in country {ct} to {limit_countries[ct]} of 1990 levels, i.e. {limit} tCO2/a")
+        logger.info(
+            f"Limiting emissions in country {ct} to {limit_countries[ct]:.1%} of "
+            f"1990 levels, i.e. {limit:,.2f} tCO2/a",
+        )
 
         lhs = []
 


### PR DESCRIPTION
Here is a small example how we can improve the printout of numeric values in the logging to make it more readable:

```
INFO:constraints.general:Limiting emissions in country NL to 91.7% of 1990 levels, i.e. 149,310,318.80 tCO2/a
```

(ignore the file reference)
