### PR TITLE
Setting up main Ariadne scenarios

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,12 +5,17 @@
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   name:
-  - 240219-test/normal
+  - KN2045_Bal_v4
+  - KN2045_Elec_v4
+  - KN2045_H2_v4
+  # - KN2045plus_EasyRide
+  # - KN2045plus_LowDemand
+  # - KN2045minus_WorstCase
+  # - KN2045minus_SupplyFocus
   scenarios:
     enable: true
   shared_resources: true #stops recalculating
   disable_progressbar: true
-
 
 iiasa_database:
   db_name: ariadne_intern
@@ -101,45 +106,32 @@ co2_budget_national:
   2050:
     DE: -0.024
 
-limits_min:
-  Generator:
-    onwind:
-      DE:
-        2020: 50
-        2025: 60
-        2030: 100
-        2035: 120
-        2040: 160
-        2045: 170
-        2050: 180
-    offwind:
-      DE:
-        2020: 1
-        2025: 7
-        2030: 20
-        2035: 25
-        2040: 25
-        2045: 25
-        2050: 25
-    solar:
-      DE:
-        2020: 50
-        2025: 80
-        2030: 215
-        2035: 250
-        2040: 300
-        2045: 350
-        2050: 400
-  Link:
-    H2 Electrolysis:
-      DE:
-        2020: 0
-        2025: 1
-        2030: 10
-        2035: 20
-        2040: 50
-        2045: 60
-        2050: 80
+limits_capacity_min:
+    Generator:
+      onwind:
+        DE:
+          2020: 48
+          2025: 61
+          2030: 115 # Wind-an-Land Law
+          2035: 157 # Wind-an-Land Law
+          2040: 160 # Wind-an-Land Law
+          2045: 160
+      offwind:
+        DE:
+          2020: 7.77
+          2025: 8
+          2030: 30 # Wind-auf-See Law
+          2035: 40 # 40 Wind-auf-See Law
+          2040: 41 #55
+          2045: 70 #70 Wind-auf-See Law
+      solar:
+        DE:
+          2020: 59
+          2025: 94.7
+          2030: 215 # PV strategy
+          2035: 307.5
+          2040: 400 # PV strategy
+          2045: 400
 
 h2_import_max:
   DE:
@@ -171,6 +163,15 @@ first_technology_occurrence:
     H2 pipeline: 2025
     H2 Electrolysis: 2025
     H2 pipeline retrofitted: 2025
+
+renewable:
+  offwind-ac:
+    capacity_per_sqkm: 8
+  offwind-dc:
+    capacity_per_sqkm: 8
+
+costs:
+  version: v0.8.0
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -260,6 +260,8 @@ plotting:
   tech_colors:
     load: "#111100"
     H2 pipeline (Kernnetz): '#6b3161'
+    fossil oil import: '#c9c9c9'
+    e-fuels: '#c9c9c9'
   countries:
   - all
   - DE

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,8 +6,8 @@
 run:
   name:
   - KN2045_Bal_v4
-  # - KN2045_Elec_v4
-  # - KN2045_H2_v4
+  - KN2045_Elec_v4
+  - KN2045_H2_v4
   # - KN2045plus_EasyRide
   # - KN2045plus_LowDemand
   # - KN2045minus_WorstCase

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,7 +5,7 @@
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   name:
-  - normal
+  - 240219-test/normal
   scenarios:
     enable: true
   shared_resources: true #stops recalculating
@@ -34,15 +34,15 @@ scenario:
   opts:
   - ''
   sector_opts:
-    - 365H-T-H-B-I-A
+    - none
   planning_horizons:
   - 2020
   #- 2025
   - 2030
   #- 2035
-  - 2040
+  #- 2040
   #- 2045
-  - 2050
+  #- 2050
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries
 # Germany plus 12 "Stromnachbarn"
@@ -68,6 +68,8 @@ clustering:
     'NO': 0.0454
     'PL': 0.0454
     'SE': 0.0454
+  temporal:
+    resolution_sector: 3H
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#co2-budget
 co2_budget:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,8 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  name: "240216-3H-5A"
+  name:
+  - normal
   scenarios:
     enable: true
   shared_resources: true #stops recalculating
@@ -33,14 +34,14 @@ scenario:
   opts:
   - ''
   sector_opts:
-    - 3H-T-H-B-I-A
+    - 365H-T-H-B-I-A
   planning_horizons:
   - 2020
-  - 2025
+  #- 2025
   - 2030
-  - 2035
+  #- 2035
   - 2040
-  - 2045
+  #- 2045
   - 2050
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -170,7 +170,7 @@ renewable:
     capacity_per_sqkm: 8
 
 costs:
-  version: v0.8.0
+  version: v0.8.1
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,8 +6,8 @@
 run:
   name:
   - KN2045_Bal_v4
-  - KN2045_Elec_v4
-  - KN2045_H2_v4
+  # - KN2045_Elec_v4
+  # - KN2045_H2_v4
   # - KN2045plus_EasyRide
   # - KN2045plus_LowDemand
   # - KN2045minus_WorstCase
@@ -42,12 +42,11 @@ scenario:
     - none
   planning_horizons:
   - 2020
-  #- 2025
+  - 2025
   - 2030
-  #- 2035
-  #- 2040
-  #- 2045
-  #- 2050
+  - 2035
+  - 2040
+  - 2045
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries
 # Germany plus 12 "Stromnachbarn"

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -1,28 +1,13 @@
-# -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: : 2017-2023 The PyPSA-Eur Authors
-#
-# SPDX-License-Identifier: MIT
-
 KN2045_Bal_v4:
-# Ausgewogener Mix an Technologien zur Dekarbonisierung der Sektoren
-# Breites Energieträgerportfolio in der Endenergie (Strom, Wasserstoff, synthetische Kraftstoffe)
-# Ausbau der erneuerbare Stromerzeugung erreicht politisch gesetzte Ziele
-# Importe erneuerbar erzeugter Energien auf mittlerem Niveau
-# dient als Referenzszenario in der Familie der Ariadne-Szenarien
-
   clustering:
     temporal:
       resolution_sector: 365H
-
   iiasa_database:
     db_name: ariadne_intern
-    model_name: Hybrid # should be Leitmodell
-    scenario: 8Gt_EnSec # should be consistent with KN2045_Bal_v4
+    model_name: Hybrid
     region: Deutschland
-
-  # boundary condition of maximum volumes
+    scenario: 8Gt_EnSec
   limits_volume_max:
-    # constrain electricity import in TWh
     electricity_import:
       DE:
         2020: 0
@@ -30,34 +15,31 @@ KN2045_Bal_v4:
         2030: 0
         2035: 40
         2040: 80
-        2045: 125 # scenario guidelines
-    # constrain hydrogen import in TWh
-    h2_import:
-      DE:
-        2020: 0
-        2025: 5
-        2030: 15 # scenario guidelines 
-        2035: 115
-        2040: 220
-        2045: 325 # scenario guidelines
-    # import of h2 derivatives in TWh
-    h2_derivate_import:
-      DE:
-        2020: 0
-        2025: 0
-        2030: 10 # scenario guidelines
-        2035: 105
-        2040: 200
-        2045: 300 # scenario guidelines
+        2045: 125
     electrolysis:
       DE:
         2020: 0
         2025: 5
-        2030: 45 # scenario guidelines
+        2030: 45
         2035: 130
         2040: 215
-        2045: 300 # scenario guidelines
-  # boundary condition of minimum volumes
+        2045: 300
+    h2_derivate_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 10
+        2035: 105
+        2040: 200
+        2045: 300
+    h2_import:
+      DE:
+        2020: 0
+        2025: 5
+        2030: 15
+        2035: 115
+        2040: 220
+        2045: 325
   limits_volume_min:
     electrolysis:
       DE:
@@ -67,73 +49,60 @@ KN2045_Bal_v4:
         2035: 0
         2040: 0
         2045: 0
-  # sector boundary conditions
   sector:
-    # technology mix in transportation from "REMIND Hybrid 8Gt_Bal_v3"
+    land_transport_electric_share:
+      land_transport_electric_share: null
+      2020: 0.0047
+      2025: 0.0608
+      2030: 0.2722
+      2035: 0.5577
+      2040: 0.7713
+      2045: 0.8931
     land_transport_fuel_cell_share:
       2020: 0.004
-      2025: 0.036
-      2030: 0.067
-      2035: 0.048
-      2040: 0.025
-      2045: 0.009
-    land_transport_electric_share:
-      2020: 0.005
-      2025: 0.061
-      2030: 0.243
-      2035: 0.520
-      2040: 0.740
-      2045: 0.874
+      2025: 0.0351
+      2030: 0.0664
+      2035: 0.0462
+      2040: 0.0235
+      2045: 0.0076
     land_transport_ice_share:
-      2020: 0.991
-      2025: 0.903
-      2030: 0.690
-      2035: 0.432
-      2040: 0.235
-      2045: 0.118
-    # technology mix in navigation
+      2020: 0.9913
+      2025: 0.9041
+      2030: 0.6614
+      2035: 0.3961
+      2040: 0.2052
+      2045: 0.0993
     shipping_hydrogen_share:
-      2020: 0.000
-      2025: 0.000
-      2030: 0.024
-      2035: 0.052
-      2040: 0.080
-      2045: 0.114
+      2020: 0.0
+      2025: 0.0
+      2030: 0.0218
+      2035: 0.0504
+      2040: 0.0804
+      2045: 0.0937
     shipping_methanol_share:
-      2020: 0.000
-      2025: 0.000
-      2030: 0.000
-      2035: 0.000
-      2040: 0.000
-      2045: 0.000
+      2020: 0.0
+      2025: 0.0
+      2030: 0.0
+      2035: 0.0
+      2040: 0.0
+      2045: 0.0
     shipping_oil_share:
-      2020: 1.000
-      2025: 1.000
-      2030: 0.976
-      2035: 0.948
-      2040: 0.920
-      2045: 0.886
-
-############################################################################################################
-
+      2020: 1.0
+      2025: 1.0
+      2030: 0.9782
+      2035: 0.9496
+      2040: 0.9196
+      2045: 0.9063
 KN2045_Elec_v4:
-# Fokus auf dem Hochlauf von Technologien zur direkten Elektrifizierung der Sektoren
-# Strom als präferierter Energieträger in der Endenergie, andere Energieträger ergänzend, wo nötig (Wasserstoff, synthetische Kraftstoffe)
-# Ausbau der erneuerbaren Stromerzeugung erreicht politisch gesetzte Ziele
-# Importe erneuerbar erzeugter Energien auf mittlerem Niveau
-
   clustering:
     temporal:
       resolution_sector: 365H
-
   iiasa_database:
     db_name: ariadne_intern
-    model_name: Hybrid # should be Leitmodell
-    scenario: 8Gt_EnSec # should be consistent with KN2045_Elec_v4
+    model_name: Hybrid
     region: Deutschland
-
+    scenario: 8Gt_EnSec
   limits_volume_max:
-    # constrain electricity import in TWh
     electricity_import:
       DE:
         2020: 0
@@ -141,34 +110,31 @@ KN2045_Elec_v4:
         2030: 0
         2035: 50
         2040: 100
-        2045: 150 # scenario guidelines
-    # constrain hydrogen import in TWh
-    h2_import:
-      DE:
-        2020: 0
-        2025: 5
-        2030: 10 # scenario guidelines 
-        2035: 90
-        2040: 170
-        2045: 250 # scenario guidelines
-    # import of h2 derivatives in TWh
-    h2_derivate_import:
-      DE:
-        2020: 0
-        2025: 0
-        2030: 10 # scenario guidelines
-        2035: 70
-        2040: 130
-        2045: 200 # scenario guidelines
+        2045: 150
     electrolysis:
       DE:
         2020: 0
         2025: 5
-        2030: 45 # scenario guidelines
+        2030: 45
         2035: 95
         2040: 145
-        2045: 200 # scenario guidelines
-  # boundary condition of minimum volumes
+        2045: 200
+    h2_derivate_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 10
+        2035: 70
+        2040: 130
+        2045: 200
+    h2_import:
+      DE:
+        2020: 0
+        2025: 5
+        2030: 10
+        2035: 90
+        2040: 170
+        2045: 250
   limits_volume_min:
     electrolysis:
       DE:
@@ -178,73 +144,59 @@ KN2045_Elec_v4:
         2035: 0
         2040: 0
         2045: 0
-
   sector:
-    # technology mix in transportation from "REMIND Hybrid 8Gt_Bal_v3"
+    land_transport_electric_share:
+      2020: 0.0047
+      2025: 0.0608
+      2030: 0.2722
+      2035: 0.5577
+      2040: 0.7713
+      2045: 0.8931
     land_transport_fuel_cell_share:
       2020: 0.004
-      2025: 0.036
-      2030: 0.067
-      2035: 0.048
-      2040: 0.025
-      2045: 0.009
-    land_transport_electric_share:
-      2020: 0.005
-      2025: 0.061
-      2030: 0.243
-      2035: 0.520
-      2040: 0.740
-      2045: 0.874
+      2025: 0.0351
+      2030: 0.0664
+      2035: 0.0462
+      2040: 0.0235
+      2045: 0.0076
     land_transport_ice_share:
-      2020: 0.991
-      2025: 0.903
-      2030: 0.690
-      2035: 0.432
-      2040: 0.235
-      2045: 0.118
-
+      2020: 0.9913
+      2025: 0.9041
+      2030: 0.6614
+      2035: 0.3961
+      2040: 0.2052
+      2045: 0.0993
     shipping_hydrogen_share:
-      2020: 0.000
-      2025: 0.000
-      2030: 0.024
-      2035: 0.052
-      2040: 0.080
-      2045: 0.114
+      2020: 0.0
+      2025: 0.0
+      2030: 0.0218
+      2035: 0.0504
+      2040: 0.0804
+      2045: 0.0937
     shipping_methanol_share:
-      2020: 0.000
-      2025: 0.000
-      2030: 0.000
-      2035: 0.000
-      2040: 0.000
-      2045: 0.000
+      2020: 0.0
+      2025: 0.0
+      2030: 0.0
+      2035: 0.0
+      2040: 0.0
+      2045: 0.0
     shipping_oil_share:
-      2020: 1.000
-      2025: 1.000
-      2030: 0.976
-      2035: 0.948
-      2040: 0.920
-      2045: 0.886
-
-############################################################################################################
-
+      2020: 1.0
+      2025: 1.0
+      2030: 0.9782
+      2035: 0.9496
+      2040: 0.9196
+      2045: 0.9063
 KN2045_H2_v4:
-# Fokus stärker auf dem Hochlauf von Technologien zur indirekten Elektrifizierung der Sektoren
-# Verstärkter Einsatz von Wasserstoff und synthetischen Kraftstoffen - erneuerbar erzeugt und auch importiert
-# Direkte Elektrifizierung spielt dennoch wesentliche Rolle bei der Dekarbonisierung der Endenergie
-# Ausbau der erneuerbaren Stromerzeugung erreicht politisch gesetzte Ziele
-
   clustering:
     temporal:
       resolution_sector: 365H
-
   iiasa_database:
     db_name: ariadne_intern
-    model_name: Hybrid # should be Leitmodell
-    scenario: 8Gt_EnSec # should be consistent with KN2045_Elec_v4
+    model_name: Hybrid
     region: Deutschland
-
+    scenario: 8Gt_EnSec
   limits_volume_max:
-    # constrain electricity import in TWh
     electricity_import:
       DE:
         2020: 0
@@ -252,33 +204,30 @@ KN2045_H2_v4:
         2030: 0
         2035: 30
         2040: 70
-        2045: 100 # scenario guidelines
-    # constrain hydrogen import in TWh
-    h2_import:
+        2045: 100
+    electrolysis:
       DE:
-        2020: 0
         2025: 5
-        2030: 45 # scenario guidelines 
-        2035: 155
-        2040: 265
-        2045: 400 # scenario guidelines
-    # import of h2 derivatives in TWh
+        2030: 45
+        2035: 160
+        2040: 275
+        2045: 400
     h2_derivate_import:
       DE:
         2020: 0
         2025: 0
-        2030: 10 # scenario guidelines
+        2030: 10
         2035: 140
         2040: 270
-        2045: 400 # scenario guidelines
-    electrolysis:
+        2045: 400
+    h2_import:
       DE:
+        2020: 0
         2025: 5
-        2030: 45 # scenario guidelines
-        2035: 160
-        2040: 275
-        2045: 400 # scenario guidelines
-
+        2030: 45
+        2035: 155
+        2040: 265
+        2045: 400
   limits_volume_min:
     electrolysis:
       DE:
@@ -287,57 +236,46 @@ KN2045_H2_v4:
         2035: 0
         2040: 0
         2045: 200
-
   sector:
-    # technology mix in transportation from "REMIND Hybrid 8Gt_Bal_v3"
+    land_transport_electric_share:
+      2020: 0.0047
+      2025: 0.0608
+      2030: 0.2722
+      2035: 0.5577
+      2040: 0.7713
+      2045: 0.8931
     land_transport_fuel_cell_share:
       2020: 0.004
-      2025: 0.036
-      2030: 0.067
-      2035: 0.048
-      2040: 0.025
-      2045: 0.009
-    land_transport_electric_share:
-      2020: 0.005
-      2025: 0.061
-      2030: 0.243
-      2035: 0.520
-      2040: 0.740
-      2045: 0.874
+      2025: 0.0351
+      2030: 0.0664
+      2035: 0.0462
+      2040: 0.0235
+      2045: 0.0076
     land_transport_ice_share:
-      2020: 0.991
-      2025: 0.903
-      2030: 0.690
-      2035: 0.432
-      2040: 0.235
-      2045: 0.118
-    # technology mix in navigation
+      2020: 0.9913
+      2025: 0.9041
+      2030: 0.6614
+      2035: 0.3961
+      2040: 0.2052
+      2045: 0.0993
     shipping_hydrogen_share:
-      2020: 0.000
-      2025: 0.000
-      2030: 0.024
-      2035: 0.052
-      2040: 0.080
-      2045: 0.114
+      2020: 0.0
+      2025: 0.0
+      2030: 0.0218
+      2035: 0.0504
+      2040: 0.0804
+      2045: 0.0937
     shipping_methanol_share:
-      2020: 0.000
-      2025: 0.000
-      2030: 0.000
-      2035: 0.000
-      2040: 0.000
-      2045: 0.000
+      2020: 0.0
+      2025: 0.0
+      2030: 0.0
+      2035: 0.0
+      2040: 0.0
+      2045: 0.0
     shipping_oil_share:
-      2020: 1.000
-      2025: 1.000
-      2030: 0.976
-      2035: 0.948
-      2040: 0.920
-      2045: 0.886
-
-# KN2045plus_EasyRide:
-
-# KN2045plus_LowDemand:
-
-# KN2045minus_WorstCase:
-
-# KN2045minus_SupplyFocus:
+      2020: 1.0
+      2025: 1.0
+      2030: 0.9782
+      2035: 0.9496
+      2040: 0.9196
+      2045: 0.9063

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -11,16 +11,15 @@
 #   electricity:
 #       renewable_carriers: [wind, solar] # override the list of renewable carriers
 
-normal:
-  electricity:
-    renewable_carriers:
-    - solar
-    - onwind
-    - offwind-ac
-    - offwind-dc
-    - hydro
+240219-test/normal:
+  clustering:
+    temporal:
+      resolution_sector: 365H
 
 hydrogen:
+  clustering:
+    temporal:
+      resolution_sector: 365H
   limits_min:
     Link:
       H2 Electrolysis:

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -1,13 +1,28 @@
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText: : 2017-2023 The PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: MIT
+
 KN2045_Bal_v4:
+# Ausgewogener Mix an Technologien zur Dekarbonisierung der Sektoren
+# Breites Energieträgerportfolio in der Endenergie (Strom, Wasserstoff, synthetische Kraftstoffe)
+# Ausbau der erneuerbare Stromerzeugung erreicht politisch gesetzte Ziele
+# Importe erneuerbar erzeugter Energien auf mittlerem Niveau
+# dient als Referenzszenario in der Familie der Ariadne-Szenarien
+
   clustering:
     temporal:
       resolution_sector: 365H
+
   iiasa_database:
     db_name: ariadne_intern
-    model_name: Hybrid
+    model_name: Hybrid # should be Leitmodell
+    scenario: 8Gt_EnSec # should be consistent with KN2045_Bal_v4
     region: Deutschland
-    scenario: 8Gt_EnSec
+
+  # boundary condition of maximum volumes
   limits_volume_max:
+    # constrain electricity import in TWh
     electricity_import:
       DE:
         2020: 0
@@ -49,9 +64,9 @@ KN2045_Bal_v4:
         2035: 0
         2040: 0
         2045: 0
+  # sector boundary conditions
   sector:
     land_transport_electric_share:
-      land_transport_electric_share: null
       2020: 0.0047
       2025: 0.0608
       2030: 0.2722
@@ -93,16 +108,24 @@ KN2045_Bal_v4:
       2035: 0.9496
       2040: 0.9196
       2045: 0.9063
+
 KN2045_Elec_v4:
+# Fokus auf dem Hochlauf von Technologien zur direkten Elektrifizierung der Sektoren
+# Strom als präferierter Energieträger in der Endenergie, andere Energieträger ergänzend, wo nötig (Wasserstoff, synthetische Kraftstoffe)
+# Ausbau der erneuerbaren Stromerzeugung erreicht politisch gesetzte Ziele
+# Importe erneuerbar erzeugter Energien auf mittlerem Niveau
+
   clustering:
     temporal:
       resolution_sector: 365H
+
   iiasa_database:
     db_name: ariadne_intern
     model_name: Hybrid
     region: Deutschland
     scenario: 8Gt_EnSec
   limits_volume_max:
+    # constrain electricity import in TWh
     electricity_import:
       DE:
         2020: 0
@@ -144,6 +167,7 @@ KN2045_Elec_v4:
         2035: 0
         2040: 0
         2045: 0
+
   sector:
     land_transport_electric_share:
       2020: 0.0047
@@ -187,16 +211,25 @@ KN2045_Elec_v4:
       2035: 0.9496
       2040: 0.9196
       2045: 0.9063
+
 KN2045_H2_v4:
+# Fokus stärker auf dem Hochlauf von Technologien zur indirekten Elektrifizierung der Sektoren
+# Verstärkter Einsatz von Wasserstoff und synthetischen Kraftstoffen - erneuerbar erzeugt und auch importiert
+# Direkte Elektrifizierung spielt dennoch wesentliche Rolle bei der Dekarbonisierung der Endenergie
+# Ausbau der erneuerbaren Stromerzeugung erreicht politisch gesetzte Ziele
+
   clustering:
     temporal:
       resolution_sector: 365H
+
   iiasa_database:
     db_name: ariadne_intern
-    model_name: Hybrid
+    model_name: Hybrid # should be Leitmodell
+    scenario: 8Gt_EnSec # should be consistent with KN2045_Elec_v4
     region: Deutschland
-    scenario: 8Gt_EnSec
+
   limits_volume_max:
+    # constrain electricity import in TWh
     electricity_import:
       DE:
         2020: 0
@@ -204,30 +237,34 @@ KN2045_H2_v4:
         2030: 0
         2035: 30
         2040: 70
-        2045: 100
-    electrolysis:
-      DE:
-        2025: 5
-        2030: 45
-        2035: 160
-        2040: 275
-        2045: 400
-    h2_derivate_import:
-      DE:
-        2020: 0
-        2025: 0
-        2030: 10
-        2035: 140
-        2040: 270
-        2045: 400
+        2045: 100 # scenario guidelines
+    # constrain hydrogen import in TWh
     h2_import:
       DE:
         2020: 0
         2025: 5
-        2030: 45
+        2030: 45 # scenario guidelines 
         2035: 155
         2040: 265
-        2045: 400
+        2045: 400 # scenario guidelines
+    # import of h2 derivatives in TWh
+    h2_derivate_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 10 # scenario guidelines
+        2035: 140
+        2040: 270
+        2045: 400 # scenario guidelines
+    electrolysis:
+      DE:
+        2020: 0
+        2025: 5
+        2030: 45 # scenario guidelines
+        2035: 160
+        2040: 275
+        2045: 400 # scenario guidelines
+
   limits_volume_min:
     electrolysis:
       DE:
@@ -236,6 +273,7 @@ KN2045_H2_v4:
         2035: 0
         2040: 0
         2045: 200
+
   sector:
     land_transport_electric_share:
       2020: 0.0047

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText: : 2017-2023 The PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: MIT
+
+# This file is used to define the scenarios that are run by snakemake. Each entry on the first level is a scenario. Each scenario can contain configuration overrides with respect to the config/config.yaml settings.
+#
+# Example
+#
+# custom-scenario: # name of the scenario
+#   electricity:
+#       renewable_carriers: [wind, solar] # override the list of renewable carriers
+
+normal:
+  electricity:
+    renewable_carriers:
+    - solar
+    - onwind
+    - offwind-ac
+    - offwind-dc
+    - hydro
+
+hydrogen:
+  limits_min:
+    Link:
+      H2 Electrolysis:
+        DE:
+          2040: 100
+          2045: 120
+          2050: 160

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -3,27 +3,341 @@
 #
 # SPDX-License-Identifier: MIT
 
-# This file is used to define the scenarios that are run by snakemake. Each entry on the first level is a scenario. Each scenario can contain configuration overrides with respect to the config/config.yaml settings.
-#
-# Example
-#
-# custom-scenario: # name of the scenario
-#   electricity:
-#       renewable_carriers: [wind, solar] # override the list of renewable carriers
+KN2045_Bal_v4:
+# Ausgewogener Mix an Technologien zur Dekarbonisierung der Sektoren
+# Breites Energieträgerportfolio in der Endenergie (Strom, Wasserstoff, synthetische Kraftstoffe)
+# Ausbau der erneuerbare Stromerzeugung erreicht politisch gesetzte Ziele
+# Importe erneuerbar erzeugter Energien auf mittlerem Niveau
+# dient als Referenzszenario in der Familie der Ariadne-Szenarien
 
-240219-test/normal:
   clustering:
     temporal:
       resolution_sector: 365H
 
-hydrogen:
+  iiasa_database:
+    db_name: ariadne_intern
+    model_name: Hybrid # should be Leitmodell
+    scenario: 8Gt_EnSec # should be consistent with KN2045_Bal_v4
+    region: Deutschland
+
+  # boundary condition of maximum volumes
+  limits_volume_max:
+    # constrain electricity import in TWh
+    electricity_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 0
+        2035: 40
+        2040: 80
+        2045: 125 # scenario guidelines
+    # constrain hydrogen import in TWh
+    h2_import:
+      DE:
+        2020: 0
+        2025: 5
+        2030: 15 # scenario guidelines 
+        2035: 115
+        2040: 220
+        2045: 325 # scenario guidelines
+    # import of h2 derivatives in TWh
+    h2_derivate_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 10 # scenario guidelines
+        2035: 105
+        2040: 200
+        2045: 300 # scenario guidelines
+    electrolysis:
+      DE:
+        2020: 0
+        2025: 5
+        2030: 45 # scenario guidelines
+        2035: 130
+        2040: 215
+        2045: 300 # scenario guidelines
+  # boundary condition of minimum volumes
+  limits_volume_min:
+    electrolysis:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 0
+        2035: 0
+        2040: 0
+        2045: 0
+  # sector boundary conditions
+  sector:
+    # technology mix in transportation from "REMIND Hybrid 8Gt_Bal_v3"
+    land_transport_fuel_cell_share:
+      2020: 0.004
+      2025: 0.036
+      2030: 0.067
+      2035: 0.048
+      2040: 0.025
+      2045: 0.009
+    land_transport_electric_share:
+      2020: 0.005
+      2025: 0.061
+      2030: 0.243
+      2035: 0.520
+      2040: 0.740
+      2045: 0.874
+    land_transport_ice_share:
+      2020: 0.991
+      2025: 0.903
+      2030: 0.690
+      2035: 0.432
+      2040: 0.235
+      2045: 0.118
+    # technology mix in navigation
+    shipping_hydrogen_share:
+      2020: 0.000
+      2025: 0.000
+      2030: 0.024
+      2035: 0.052
+      2040: 0.080
+      2045: 0.114
+    shipping_methanol_share:
+      2020: 0.000
+      2025: 0.000
+      2030: 0.000
+      2035: 0.000
+      2040: 0.000
+      2045: 0.000
+    shipping_oil_share:
+      2020: 1.000
+      2025: 1.000
+      2030: 0.976
+      2035: 0.948
+      2040: 0.920
+      2045: 0.886
+
+############################################################################################################
+
+KN2045_Elec_v4:
+# Fokus auf dem Hochlauf von Technologien zur direkten Elektrifizierung der Sektoren
+# Strom als präferierter Energieträger in der Endenergie, andere Energieträger ergänzend, wo nötig (Wasserstoff, synthetische Kraftstoffe)
+# Ausbau der erneuerbaren Stromerzeugung erreicht politisch gesetzte Ziele
+# Importe erneuerbar erzeugter Energien auf mittlerem Niveau
+
   clustering:
     temporal:
       resolution_sector: 365H
-  limits_min:
-    Link:
-      H2 Electrolysis:
-        DE:
-          2040: 100
-          2045: 120
-          2050: 160
+
+  iiasa_database:
+    db_name: ariadne_intern
+    model_name: Hybrid # should be Leitmodell
+    scenario: 8Gt_EnSec # should be consistent with KN2045_Elec_v4
+    region: Deutschland
+
+  limits_volume_max:
+    # constrain electricity import in TWh
+    electricity_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 0
+        2035: 50
+        2040: 100
+        2045: 150 # scenario guidelines
+    # constrain hydrogen import in TWh
+    h2_import:
+      DE:
+        2020: 0
+        2025: 5
+        2030: 10 # scenario guidelines 
+        2035: 90
+        2040: 170
+        2045: 250 # scenario guidelines
+    # import of h2 derivatives in TWh
+    h2_derivate_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 10 # scenario guidelines
+        2035: 70
+        2040: 130
+        2045: 200 # scenario guidelines
+    electrolysis:
+      DE:
+        2020: 0
+        2025: 5
+        2030: 45 # scenario guidelines
+        2035: 95
+        2040: 145
+        2045: 200 # scenario guidelines
+  # boundary condition of minimum volumes
+  limits_volume_min:
+    electrolysis:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 0
+        2035: 0
+        2040: 0
+        2045: 0
+
+  sector:
+    # technology mix in transportation from "REMIND Hybrid 8Gt_Bal_v3"
+    land_transport_fuel_cell_share:
+      2020: 0.004
+      2025: 0.036
+      2030: 0.067
+      2035: 0.048
+      2040: 0.025
+      2045: 0.009
+    land_transport_electric_share:
+      2020: 0.005
+      2025: 0.061
+      2030: 0.243
+      2035: 0.520
+      2040: 0.740
+      2045: 0.874
+    land_transport_ice_share:
+      2020: 0.991
+      2025: 0.903
+      2030: 0.690
+      2035: 0.432
+      2040: 0.235
+      2045: 0.118
+
+    shipping_hydrogen_share:
+      2020: 0.000
+      2025: 0.000
+      2030: 0.024
+      2035: 0.052
+      2040: 0.080
+      2045: 0.114
+    shipping_methanol_share:
+      2020: 0.000
+      2025: 0.000
+      2030: 0.000
+      2035: 0.000
+      2040: 0.000
+      2045: 0.000
+    shipping_oil_share:
+      2020: 1.000
+      2025: 1.000
+      2030: 0.976
+      2035: 0.948
+      2040: 0.920
+      2045: 0.886
+
+############################################################################################################
+
+KN2045_H2_v4:
+# Fokus stärker auf dem Hochlauf von Technologien zur indirekten Elektrifizierung der Sektoren
+# Verstärkter Einsatz von Wasserstoff und synthetischen Kraftstoffen - erneuerbar erzeugt und auch importiert
+# Direkte Elektrifizierung spielt dennoch wesentliche Rolle bei der Dekarbonisierung der Endenergie
+# Ausbau der erneuerbaren Stromerzeugung erreicht politisch gesetzte Ziele
+
+  clustering:
+    temporal:
+      resolution_sector: 365H
+
+  iiasa_database:
+    db_name: ariadne_intern
+    model_name: Hybrid # should be Leitmodell
+    scenario: 8Gt_EnSec # should be consistent with KN2045_Elec_v4
+    region: Deutschland
+
+  limits_volume_max:
+    # constrain electricity import in TWh
+    electricity_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 0
+        2035: 30
+        2040: 70
+        2045: 100 # scenario guidelines
+    # constrain hydrogen import in TWh
+    h2_import:
+      DE:
+        2020: 0
+        2025: 5
+        2030: 45 # scenario guidelines 
+        2035: 155
+        2040: 265
+        2045: 400 # scenario guidelines
+    # import of h2 derivatives in TWh
+    h2_derivate_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 10 # scenario guidelines
+        2035: 140
+        2040: 270
+        2045: 400 # scenario guidelines
+    electrolysis:
+      DE:
+        2025: 5
+        2030: 45 # scenario guidelines
+        2035: 160
+        2040: 275
+        2045: 400 # scenario guidelines
+
+  limits_volume_min:
+    electrolysis:
+      DE:
+        2025: 0
+        2030: 0
+        2035: 0
+        2040: 0
+        2045: 200
+
+  sector:
+    # technology mix in transportation from "REMIND Hybrid 8Gt_Bal_v3"
+    land_transport_fuel_cell_share:
+      2020: 0.004
+      2025: 0.036
+      2030: 0.067
+      2035: 0.048
+      2040: 0.025
+      2045: 0.009
+    land_transport_electric_share:
+      2020: 0.005
+      2025: 0.061
+      2030: 0.243
+      2035: 0.520
+      2040: 0.740
+      2045: 0.874
+    land_transport_ice_share:
+      2020: 0.991
+      2025: 0.903
+      2030: 0.690
+      2035: 0.432
+      2040: 0.235
+      2045: 0.118
+    # technology mix in navigation
+    shipping_hydrogen_share:
+      2020: 0.000
+      2025: 0.000
+      2030: 0.024
+      2035: 0.052
+      2040: 0.080
+      2045: 0.114
+    shipping_methanol_share:
+      2020: 0.000
+      2025: 0.000
+      2030: 0.000
+      2035: 0.000
+      2040: 0.000
+      2045: 0.000
+    shipping_oil_share:
+      2020: 1.000
+      2025: 1.000
+      2030: 0.976
+      2035: 0.948
+      2040: 0.920
+      2045: 0.886
+
+# KN2045plus_EasyRide:
+
+# KN2045plus_LowDemand:
+
+# KN2045minus_WorstCase:
+
+# KN2045minus_SupplyFocus:

--- a/environment.yaml
+++ b/environment.yaml
@@ -52,6 +52,7 @@ dependencies:
 - pypsa>=0.27.0
 - highs
 - pyam
+- ruamel.yaml
 
   # Keep in conda environment when calling ipython
 - ipython

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -221,3 +221,25 @@ if config["wasserstoff_kernnetz"]["enable"]:
             clustered_h2_network="resources/wasserstoff_kernnetz_elec_s{simpl}_{clusters}.csv",
         script:
             "scripts/cluster_wasserstoff_kernnetz.py"
+
+rule build_scenarios:
+    params:
+        iiasa_usr=os.environ["IIASA_USERNAME"],
+        iiasa_pwd=os.environ["IIASA_PASSWORD"],
+        iiasa_model=config["iiasa_database"]["model_name"],
+        iiasa_scenario=config["iiasa_database"]["scenario"],
+        scenario_name=config["run"]["name"],
+    input:
+        "config/scenarios.yaml"
+    log:
+        "logs/build_scenarios.log"
+    script:
+        "scripts/build_scenarios.py"
+
+rule check_sector_ratios:
+    input:
+        network=RESULTS + "postnetworks/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
+    log:
+        "logs/check_sector_ratios.log"
+    script:
+        "scripts/check_sector_ratios.py"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: MIT
 
 from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
+import yaml, sys
+
+sys.path.append("workflow/submodules/pypsa-eur/scripts")
+
+from _helpers import path_provider
 
 HTTP = HTTPRemoteProvider()
 
@@ -10,9 +15,23 @@ configfile: "workflow/submodules/pypsa-eur/config/config.default.yaml"
 configfile: "config/config.yaml"
 configfile: "config/config.personal.yaml"
 
-run = config.get("run", {})
-RDIR = run["name"] + "/" if run.get("name") else ""
-RESOURCES = "resources/" + RDIR if not run.get("shared_resources") else "resources/"
+run = config["run"]
+scenarios = run.get("scenarios", {})
+if run["name"] and scenarios.get("enable"):
+    fn = Path(scenarios["file"])
+    scenarios = yaml.safe_load(fn.read_text())
+    RDIR = "{run}/"
+    if run["name"] == "all":
+        config["run"]["name"] = list(scenarios.keys())
+elif run["name"]:
+    RDIR = run["name"] + "/"
+else:
+    RDIR = ""
+
+logs = path_provider("logs/", RDIR, run["shared_resources"])
+benchmarks = path_provider("benchmarks/", RDIR, run["shared_resources"])
+resources = path_provider("resources/", RDIR, run["shared_resources"])
+
 RESULTS = "results/" + RDIR
 
 envvars:
@@ -25,6 +44,8 @@ wildcard_constraints:
     ll="(v|c)([0-9\.]+|opt)",
     opts="[-+a-zA-Z0-9\.]*",
     sector_opts="[-+a-zA-Z0-9\.\s]*",
+    planning_horizons="[0-9]*",
+    year="[0-9]*",
 
 module pypsaeur:
     snakefile:
@@ -68,7 +89,7 @@ rule retrieve_ariadne_scenario_data:
         iiasa_usr=os.environ["IIASA_USERNAME"],
         iiasa_pwd=os.environ["IIASA_PASSWORD"]
     output:
-        data=RESOURCES + "ariadne_scenario_data.csv"
+        data=resources("ariadne_scenario_data.csv")
     log:
         "logs/retrieve_ariadne_scenario_data.log"
     resources:
@@ -76,18 +97,23 @@ rule retrieve_ariadne_scenario_data:
     script:
         "scripts/retrieve_ariadne_scenario_data.py"
 
-if config["enable"]["retrieve"] and config["enable"].get("retrieve_cost_data", True):
+#if config["enable"]["retrieve"] and config["enable"].get("retrieve_cost_data", True):
+#
+#    use rule retrieve_cost_data from pypsaeur with:
+#        output:
+#            resources("costs_{year}-original.csv"),
 
-    use rule retrieve_cost_data from pypsaeur with:
-        output:
-            "data/costs_{year}-original.csv",
+use rule prepare_sector_network from pypsaeur with:
+    input:
+        **{k: v for k, v in rules.prepare_sector_network.input.items() if k != "costs"},
+	costs=resources("modified-costs_{planning_horizons}.csv"),
 
 rule modify_cost_data:
     input:
-        costs="data/costs_{year}-original.csv",
-        modifications="ariadne-data/costs_{year}-modifications.csv",
+        costs=resources("costs_{planning_horizons}.csv"),
+        modifications="ariadne-data/costs_{planning_horizons}-modifications.csv",
     output:
-       "data/costs_{year}.csv",
+        resources("modified-costs_{planning_horizons}.csv"),
     resources:
         mem_mb=1000
     script:
@@ -102,7 +128,7 @@ rule modify_prenetwork:
         network=RESULTS
         + "prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
         wkn="resources/wasserstoff_kernnetz_elec_s{simpl}_{clusters}.csv",
-        costs="data/costs_{planning_horizons}.csv",
+        costs=resources("costs_{planning_horizons}.csv"),
     output:
         network=RESULTS
         + "prenetworks-final/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc"
@@ -120,15 +146,15 @@ use rule solve_sector_network_myopic from pypsaeur with:
         **{k: v for k, v in rules.solve_sector_network_myopic.input.items() if k != "network"},
         network=RESULTS
         + "prenetworks-final/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
-        co2_totals_name=RESOURCES + "co2_totals.csv",
+        co2_totals_name=resources("co2_totals.csv"),
 
 
 rule modify_existing_heating:
     input:
-        ariadne=RESOURCES + "ariadne_scenario_data.csv",
+        ariadne=resources("ariadne_scenario_data.csv"),
         existing_heating="data/existing_infrastructure/existing_heating_raw.csv",
     output:
-        existing_heating=RESOURCES + "existing_heating.csv",
+        existing_heating=resources("existing_heating.csv"),
     resources:
         mem_mb=1000
     script:
@@ -139,16 +165,16 @@ rule modify_existing_heating:
 use rule build_existing_heating_distribution from pypsaeur with:
     input:
         **{k: v for k, v in rules.build_existing_heating_distribution.input.items() if k != "existing_heating"},
-        existing_heating=RESOURCES + "existing_heating.csv",
+        existing_heating=resources("existing_heating.csv"),
 
 
 
 rule modify_energy_totals:
     input:
-        ariadne=RESOURCES + "ariadne_scenario_data.csv",
-        energy_totals=RESOURCES + "energy_totals.csv",
+        ariadne=resources("ariadne_scenario_data.csv"),
+        energy_totals=resources("energy_totals.csv"),
     output:
-        energy_totals=RESOURCES + "energy_totals-modified.csv",
+        energy_totals=resources("energy_totals-modified.csv"),
     resources:
         mem_mb=1000
     script:
@@ -158,7 +184,7 @@ rule modify_energy_totals:
 use rule build_population_weighted_energy_totals from pypsaeur with:
     input:
         **{k: v for k, v in rules.build_population_weighted_energy_totals.input.items() if k != "energy_totals"},
-        energy_totals=RESOURCES + "energy_totals-modified.csv",
+        energy_totals=resources("energy_totals-modified.csv"),
 
 if config["wasserstoff_kernnetz"]["enable"]:
 

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -11,13 +11,13 @@ logger = logging.getLogger(__name__)
 
 def add_min_limits(n, snapshots, investment_year, config):
 
-    for c in n.iterate_components(config["limits_min"]):
+    for c in n.iterate_components(config["limits_capacity_min"]):
         logger.info(f"Adding minimum constraints for {c.list_name}")
 
-        for carrier in config["limits_min"][c.name]:
+        for carrier in config["limits_capacity_min"][c.name]:
 
-            for ct in config["limits_min"][c.name][carrier]:
-                limit = 1e3*config["limits_min"][c.name][carrier][ct][investment_year]
+            for ct in config["limits_capacity_min"][c.name][carrier]:
+                limit = 1e3*config["limits_capacity_min"][c.name][carrier][ct][investment_year]
 
                 logger.info(f"Adding constraint on {c.name} {carrier} capacity in {ct} to be greater than {limit} MW")
 
@@ -49,8 +49,8 @@ def add_min_limits(n, snapshots, investment_year, config):
 
 def h2_import_limits(n, snapshots, investment_year, config):
 
-    for ct in config["h2_import_max"]:
-        limit = config["h2_import_max"][ct][investment_year]*1e6
+    for ct in config["limits_volume_max"]["h2_import"]:
+        limit = config["limits_volume_max"]["h2_import"][ct][investment_year]*1e6
 
         logger.info(f"limiting H2 imports in {ct} to {limit/1e6} TWh/a")
 
@@ -63,6 +63,81 @@ def h2_import_limits(n, snapshots, investment_year, config):
         lhs = incoming_p - outgoing_p
 
         cname = f"H2_import_limit-{ct}"
+
+        n.model.add_constraints(
+            lhs <= limit, name=f"GlobalConstraint-{cname}"
+        )
+        n.add(
+            "GlobalConstraint",
+            cname,
+            constant=limit,
+            sense="<=",
+            type="",
+            carrier_attribute="",
+        )
+
+def h2_production_limits(n, snapshots, investment_year, config):
+
+    for ct in config["limits_volume_max"]["electrolysis"]:
+        if ct not in config["limits_volume_min"]["electrolysis"]:
+            logger.warning(f"no lower limit for H2 electrolysis in {ct} assuming 0 TWh/a")
+            limit_lower = 0
+        else:
+            limit_lower = config["limits_volume_min"]["electrolysis"][ct][investment_year]*1e6
+        
+        limit_upper = config["limits_volume_max"]["electrolysis"][ct][investment_year]*1e6
+
+        logger.info(f"limiting H2 electrolysis in DE between {limit_lower/1e6} and {limit_upper/1e6} TWh/a")
+
+        production = n.links[(n.links.carrier == "H2 Electrolysis") & (n.links.bus0.str.contains(ct))].index
+
+        lhs = (n.model["Link-p"].loc[:, production]*n.snapshot_weightings.generators).sum()
+
+        cname_upper = f"H2_production_limit_upper-{ct}"
+        cname_lower = f"H2_production_limit_lower-{ct}"
+
+        n.model.add_constraints(
+            lhs <= limit_upper, name=f"GlobalConstraint-{cname_upper}"
+        )
+
+        n.model.add_constraints(
+            lhs >= limit_lower, name=f"GlobalConstraint-{cname_lower}"
+        )
+
+        n.add(
+            "GlobalConstraint",
+            cname_upper,
+            constant=limit_upper,
+            sense="<=",
+            type="",
+            carrier_attribute="",
+        )
+        n.add(
+            "GlobalConstraint",
+            cname_lower,
+            constant=limit_lower,
+            sense=">=",
+            type="",
+            carrier_attribute="",
+        )
+
+
+def electricity_import_limits(n, snapshots, investment_year, config):
+
+    for ct in config["limits_volume_max"]["electricity_import"]:
+        limit = config["limits_volume_max"]["electricity_import"][ct][investment_year]*1e6
+
+        logger.info(f"limiting electricity imports in {ct} to {limit/1e6} TWh/a")
+
+        incoming = n.links.index[((n.links.carrier == "DC") | (n.links.carrier == "AC")) & (n.links.bus0.str[:2] != ct) & (n.links.bus1.str[:2] == ct)]
+        outgoing = n.links.index[((n.links.carrier == "DC") | (n.links.carrier == "AC")) & (n.links.bus0.str[:2] == ct) & (n.links.bus1.str[:2] != ct)]
+
+        incoming_p = (n.model["Link-p"].loc[:, incoming]*n.snapshot_weightings.generators).sum()
+        outgoing_p = (n.model["Link-p"].loc[:, outgoing]*n.snapshot_weightings.generators).sum()
+
+        lhs = incoming_p - outgoing_p
+
+        cname = f"Electricity_import_limit-{ct}"
 
         n.model.add_constraints(
             lhs <= limit, name=f"GlobalConstraint-{cname}"
@@ -206,6 +281,34 @@ def force_boiler_profiles_existing_per_boiler(n):
     n.links["fixed_profile_scaling_opt"] = 0.
 
 
+def add_h2_derivate_limit(n, snapshots, investment_year, config):
+
+    for ct in config["limits_volume_max"]["h2_derivate_import"]:
+        limit = config["limits_volume_max"]["h2_derivate_import"][ct][investment_year]*1e6
+
+        logger.info(f"limiting H2 derivate imports in {ct} to {limit/1e6} TWh/a")
+
+        incoming = n.links.index[n.links.index.str.contains("EU renewable oil -> DE renewable oil")]
+        outgoing = n.links.index[n.links.index.str.contains("DE renewable oil -> EU oil")]
+
+        incoming_p = (n.model["Link-p"].loc[:, incoming]*n.snapshot_weightings.generators).sum()
+        outgoing_p = (n.model["Link-p"].loc[:, outgoing]*n.snapshot_weightings.generators).sum()
+
+        lhs = incoming_p - outgoing_p
+        
+        cname = f"H2_derivate_import_limit-{ct}"
+
+        n.model.add_constraints(
+            lhs <= limit, name=f"GlobalConstraint-{cname}"
+        )
+        n.add(
+            "GlobalConstraint",
+            cname,
+            constant=limit,
+            sense="<=",
+            type="",
+            carrier_attribute="",
+        )
 
 
 def additional_functionality(n, snapshots, snakemake):
@@ -217,6 +320,13 @@ def additional_functionality(n, snapshots, snakemake):
     add_min_limits(n, snapshots, investment_year, snakemake.config)
 
     h2_import_limits(n, snapshots, investment_year, snakemake.config)
+
+    electricity_import_limits(n, snapshots, investment_year, snakemake.config)
+    
+    if investment_year >= 2025:
+        h2_production_limits(n, snapshots, investment_year, snakemake.config)
+
+    add_h2_derivate_limit(n, snapshots, investment_year, snakemake.config)
 
     #force_boiler_profiles_existing_per_load(n)
     force_boiler_profiles_existing_per_boiler(n)

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -2,7 +2,7 @@
 import logging
 
 import pandas as pd
-from prepare_sector_network import emission_sectors_from_opts
+from prepare_sector_network import determine_emission_sectors
 
 from xarray import DataArray
 
@@ -94,7 +94,7 @@ def add_co2limit_country(n, limit_countries, snakemake):
     nhours = n.snapshot_weightings.generators.sum()
     nyears = nhours / 8760
 
-    sectors = emission_sectors_from_opts(n.opts)
+    sectors = determine_emission_sectors(n.config['sector'])
 
     # convert MtCO2 to tCO2
     co2_totals = 1e6 * pd.read_csv(snakemake.input.co2_totals_name, index_col=0)

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -288,7 +288,7 @@ def add_h2_derivate_limit(n, snapshots, investment_year, config):
 
         logger.info(f"limiting H2 derivate imports in {ct} to {limit/1e6} TWh/a")
 
-        incoming = n.links.index[n.links.index.str.contains("EU renewable oil -> DE renewable oil")]
+        incoming = n.links.index[n.links.index.str.contains("EU renewable oil -> DE oil")]
         outgoing = n.links.index[n.links.index.str.contains("DE renewable oil -> EU oil")]
 
         incoming_p = (n.model["Link-p"].loc[:, incoming]*n.snapshot_weightings.generators).sum()

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -6,7 +6,8 @@
 # This script reads in data from the IIASA database to create the scenario.yaml file
 
 import pyam
-import yaml
+import ruamel.yaml
+from pathlib import Path
 import pandas as pd
 import os
 
@@ -43,8 +44,9 @@ def get_shares(df):
 
 def write_to_scenario_yaml(output, scenarios, transport_share, naval_share):
     # read in yaml file
-    with open("config/scenarios.yaml", 'r') as file:
-        config = yaml.safe_load(file)
+    yaml = ruamel.yaml.YAML()
+    file_path = Path(output)
+    config = yaml.load(file_path)
     
     mapping_transport = {
         'PHEV': 'land_transport_fuel_cell_share',
@@ -64,10 +66,9 @@ def write_to_scenario_yaml(output, scenarios, transport_share, naval_share):
         for key in mapping_navigation.keys():
             for year in naval_share.columns:
                 config[scenario]["sector"][mapping_navigation[key]][year] = round(naval_share.loc[key, year].item(), 4)
-        
-    # write back to yaml file        
-    with open(output, 'w') as file:
-        yaml.dump(config, file)
+
+    # write back to yaml file
+    yaml.dump(config, file_path)
 
 
 if __name__ == "__main__":

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+# SPDX-FileCopyrightText: : 2024- The PyPSA-Eur Authors
+#
+# SPDX-License-Identifier: MIT
+
+# This script reads in data from the IIASA database to create the scenario.yaml file
+
+import pyam
+import pandas as pd
+import os
+
+def get_shares(df):
+    # Get share of vehicles for transport sector - meglecting heavy duty vehicles
+    total_transport = df.loc["Stock|Transportation|LDV"]
+    tech_transport = df.loc[["Stock|Transportation|LDV|ICE",
+                "Stock|Transportation|LDV|BEV",
+                "Stock|Transportation|LDV|PHEV",]]
+
+    transport_share = tech_transport / total_transport
+    transport_share = transport_share[[2020, 2025, 2030, 2035, 2040, 2045]]
+    transport_share.reset_index(drop=True, inplace=True)
+    transport_share.set_index(pd.Index(["ICE", "BEV", "PHEV"]), inplace=True)
+
+    # Get share of Navigation fuels
+    total_navigation = df.loc[["Final Energy|Bunkers|Navigation",
+                         "Final Energy|Transportation|Domestic Navigation"]].sum(axis=0)
+    navigation_liquid = df.loc[["Final Energy|Bunkers|Navigation",
+                         "Final Energy|Transportation|Domestic Navigation|Liquids"]].sum()
+    navigation_h2 = df.loc[["Final Energy|Transportation|Domestic Navigation|Hydrogen"]]    
+
+    h2_share = navigation_h2 / total_navigation
+    liquid_share = pd.DataFrame(navigation_liquid / total_navigation, columns=['Oil']).transpose()
+
+    h2_share.reset_index(drop=True, inplace=True)
+    h2_share.set_index(pd.Index(["H2"]), inplace=True)
+    naval_share = pd.concat([liquid_share, h2_share])
+    naval_share.loc["MeOH"] = 0.0
+    naval_share = naval_share[[2020, 2025, 2030, 2035, 2040, 2045]]
+
+    return transport_share, naval_share
+
+
+def write_to_scenario_yaml(output, scenario, transport_share, naval_share):
+    # write the data to the output file
+    with open(output, 'r') as f:
+        lines = f.readlines()
+    
+    #get first occurence of scenario
+    first = lines.index(scenario + ":\n")
+    
+    mapping_transport = {
+        'PHEV': 'land_transport_fuel_cell_share',
+        'BEV': 'land_transport_electric_share',
+        'ICE': 'land_transport_ice_share'
+    }
+    
+    # transport sector
+    start_index = []
+    for i, line in enumerate(lines):
+        if line.strip() == "land_transport_fuel_cell_share:":
+            start_index.append(i)
+        elif line.strip() == "land_transport_electric_share:":
+            start_index.append(i)
+        elif line.strip() == "land_transport_ice_share:":
+            start_index.append(i)
+
+    numb = next((i for i, num in enumerate(start_index) if num > first), None)
+    start_index = start_index[numb : numb+ 3]
+
+    j = 0
+    # Modify the content accordingly
+    for key in mapping_transport.keys():
+        idx = start_index[j] + 1
+        for col in transport_share.columns:
+            if pd.notnull(transport_share.loc[key, col]):
+                lines[idx] = f"      {col}: {transport_share.loc[key, col]:.3f}\n"
+            idx += 1
+        j += 1
+
+    # naval sector
+    mapping_navigation = {
+        'H2': 'shipping_hydrogen_share',
+        'MeOH': 'shipping_methanol_share',
+        'Oil': 'shipping_oil_share',
+    }
+    
+    # transport sector
+    start_index = []
+    for i, line in enumerate(lines):
+        if line.strip() == "shipping_hydrogen_share:":
+            start_index.append(i)
+        elif line.strip() == "shipping_methanol_share:":
+            start_index.append(i)
+        elif line.strip() == "shipping_oil_share:":
+            start_index.append(i)
+
+    numb = next((i for i, num in enumerate(start_index) if num > first), None)
+    start_index = start_index[numb : numb+ 3]
+
+    j = 0
+    # Modify the content accordingly
+    for key in mapping_navigation.keys():
+        idx = start_index[j] + 1
+        for col in naval_share.columns:
+            if pd.notnull(naval_share.loc[key, col]):
+                lines[idx] = f"      {col}: {naval_share.loc[key, col]:.3f}\n"
+            idx += 1
+        j += 1
+        
+    # Write the modified content back to the file
+    with open(output, 'w') as f:
+        f.writelines(lines)
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        import os
+        import sys
+
+        path = "../submodules/pypsa-eur/scripts"
+        sys.path.insert(0, os.path.abspath(path))
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake("build_scenarios")
+
+    # Set USERNAME and PASSWORD for the Ariadne DB
+    pyam.iiasa.set_config(
+        snakemake.params.iiasa_usr, 
+        snakemake.params.iiasa_pwd,
+    )
+
+    model_df= pyam.read_iiasa(
+        "ariadne_intern",
+        model=snakemake.params.iiasa_model,
+        scenario=snakemake.params.iiasa_scenario,
+    ).timeseries()
+
+    df = model_df.loc[snakemake.params.iiasa_model, snakemake.params.iiasa_scenario, "Deutschland"]
+
+    transport_share, naval_share = get_shares(df)
+
+    scenario = snakemake.params.scenario_name[0]
+    output = snakemake.input[0]
+    write_to_scenario_yaml(output, scenario, transport_share, naval_share)

--- a/workflow/scripts/check_sector_ratios.py
+++ b/workflow/scripts/check_sector_ratios.py
@@ -1,0 +1,34 @@
+import logging
+
+import pandas as pd
+
+import pypsa
+
+logger = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        import os
+        import sys
+
+        path = "../submodules/pypsa-eur/scripts"
+        sys.path.insert(0, os.path.abspath(path))
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake(
+            "check_sector_ratios",
+            simpl="",
+            clusters=22,
+            opts="",
+            ll="v1.2",
+            sector_opts="None",
+            planning_horizons="2030",
+            run="KN2045_Bal_v4"
+        )
+    logger.info("Check sector ratios")
+
+    n = pypsa.Network(snakemake.input.network)
+
+    # check the heating sector
+
+    # check the industry sector

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -241,15 +241,15 @@ def unravel_oilbus(n):
     """
     logger.info("Unraveling oil bus")
     # add buses
-    n.add("Bus", "DE oil")
-    n.add("Bus", "DE renewable oil")
-    n.add("Bus", "EU renewable oil")
+    n.add("Bus", "DE oil", carrier="oil")
+    n.add("Bus", "DE renewable oil", carrier="e-fuels")
+    n.add("Bus", "EU renewable oil", carrier="e-fuels")
 
     # add one generator for DE oil
     n.add("Generator",
           name="DE oil",
           bus="DE oil",
-          carrier="oil",
+          carrier="fossil oil import",
           p_nom_extendable=True,
           marginal_cost=n.generators.loc["EU oil"].marginal_cost,
           )
@@ -267,20 +267,29 @@ def unravel_oilbus(n):
     # add links between oil buses
     n.madd(
         "Link",
-        ["EU renewable oil -> DE renewable oil", "EU renewable oil -> EU oil", "DE renewable oil -> DE oil"],
-        bus0=["EU renewable oil", "EU renewable oil", "DE renewable oil"],
-        bus1=["DE renewable oil", "EU oil", "DE oil"],
-        carrier="oil",
+        ["EU renewable oil -> DE oil", "EU renewable oil -> EU oil", "DE renewable oil -> DE oil", "DE renewable oil -> EU oil"],
+        bus0=["EU renewable oil", "EU renewable oil", "DE renewable oil", "DE renewable oil"],
+        bus1=["DE renewable oil", "EU oil", "DE oil", "EU oil"],
+        carrier="e-fuels",
         p_nom=1e9,
         p_min_pu=0,
     )
 
     # add stores
+    n.add("Store",
+          "DE oil Store",
+          bus="DE oil",
+          carrier="oil",
+          e_nom_extendable=True,
+          e_cyclic=True,
+          capital_cost=0.02,
+          )
+
     n.madd(
         "Store",
-        ["DE oil Store", "DE renewable oil Store", "EU renewable oil Store"],
-        bus=["DE oil", "DE renewable oil", "EU renewable oil"],
-        carrier="oil",
+        ["DE renewable oil Store", "EU renewable oil Store"],
+        bus=["DE renewable oil", "EU renewable oil"],
+        carrier="e-fuels",
         e_nom_extendable=True,
         e_cyclic=True,
         capital_cost=0.02,


### PR DESCRIPTION
Creating the `scenarios.yaml` file for the main scenarios in the ariadne project.
- adding limits for the import of electricity, hydrogen and hydrogen derivates
- adding minimum for the installed capacity of electrolysis in Germany
- rule `build_scenarios` reads in the mobility share for land transport and navigation from the specified iiasa scenario

Open ToDos:

- [ ] `check_sector_ratios.py` for checking if sectors reach goals as specified in the [modelling protocol](https://docs.google.com/document/d/10V6o-1vPECYu5UiEi4alYS8r-CXqZSRKqJkAGKt1N0Y/edit#heading=h.scs40dks0x32)
- [ ] specify the iiasa scenarios for the electricity and hydrogen focused scenario
- [ ] adding the 4 other scenarios (already created names in `config.yaml` and `scenarios.yaml`
- [ ] check if the targets for the mobility sector are used in the same run in `build_scenarios.py` 