### PR TITLE
Import/Export of FT is subtracted/added to the national CO2 target

### DIFF
--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -200,7 +200,13 @@ def add_co2limit_country(n, limit_countries, snakemake):
 
             lhs.append((n.model["Link-p"].loc[:, links]*efficiency*n.snapshot_weightings.generators).sum())
 
-        lhs = sum(lhs)
+        incoming = n.links.index[n.links.index == "EU renewable oil -> DE oil"]
+        outgoing = n.links.index[n.links.index == "DE renewable oil -> EU oil"]
+
+        incoming_p = (n.model["Link-p"].loc[:, incoming]*n.snapshot_weightings.generators).sum()
+        outgoing_p = (n.model["Link-p"].loc[:, outgoing]*n.snapshot_weightings.generators).sum()
+
+        lhs = sum(lhs) + (outgoing_p - incoming_p)*0.2571
 
         cname = f"co2_limit-{ct}"
 


### PR DESCRIPTION
When synfuels are imported to Germany (or any country) the emissions are not accounted for in the national CO2 target. The same applies to the export of synfuels.
This PR adds in `extra_functionality.py` in the function `add_co2limit_country(n, limit_countries, snakemake)` the sum over all import and export of synfuels to/from Germany and subtract/adds multiplied by the emission factor of oil to the national CO2 target.
PR https://github.com/PyPSA/pypsa-ariadne/pull/33 is therefore obsolete. 

at the moment it will only work for "DE". If we want to enable that for any country, the untangling of the oil bus must be flexible as well.
For this look into `modify_prenetwork.py` in https://github.com/PyPSA/pypsa-ariadne/pull/39