### PR TITLE
Adding NEP21 and cost data for 2019

### DIFF
--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -1,0 +1,5 @@
+technology,parameter,value,unit,source,further description
+gas,fuel,16.0,EUR/MWh_th,Ariadne,
+oil,fuel,33.2457,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,6.7391,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
+electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"

--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -3,10 +3,10 @@ gas,fuel,16.0,EUR/MWh_th,Ariadne,
 oil,fuel,33.2457,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.7391,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump, investment, 3.319, EUR2020/kw_th, Ariadne,
-decentral ground-sourced heat pump, investment, 5.340, EUR2020/kw_th, Ariadne,
-electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
-HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
-HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
-HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
-HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,
+decentral air-sourced heat pump,investment,3.319,EUR2020/kw_th,Ariadne,
+decentral ground-sourced heat pump,investment,5.340,EUR2020/kw_th,Ariadne,
+electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
+HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
+HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
+HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
+HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,

--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -3,10 +3,10 @@ gas,fuel,16.0,EUR/MWh_th,Ariadne,
 oil,fuel,33.2457,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.7391,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3.319,EUR2020/kw_th,Ariadne,
-decentral ground-sourced heat pump,investment,5.340,EUR2020/kw_th,Ariadne,
-electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
-HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
-HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
-HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
-HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,
+decentral air-sourced heat pump,investment,3319,EUR2020/kW_th,Ariadne database
+decentral ground-sourced heat pump,investment,5340,EUR2020/kW_th,Ariadne database
+electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
+HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021
+HVDC overhead,investment,1000,EUR2020/MW/km,NEP2021
+HVDC submarine,investment,3250,EUR2020/MW/km,NEP2021

--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -3,3 +3,10 @@ gas,fuel,16.0,EUR/MWh_th,Ariadne,
 oil,fuel,33.2457,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.7391,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
+decentral air-sourced heat pump, investment, 3.319, EUR2020/kw_th, Ariadne,
+decentral ground-sourced heat pump, investment, 5.340, EUR2020/kw_th, Ariadne,
+electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
+HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
+HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
+HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
+HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,

--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,16.0,EUR/MWh_th,Ariadne,
 oil,fuel,33.2457,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.7391,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3319,EUR2020/kW_th,Ariadne database
-decentral ground-sourced heat pump,investment,5340,EUR2020/kW_th,Ariadne database
+decentral air-sourced heat pump,investment,3319,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf
+decentral ground-sourced heat pump,investment,5340,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -3,10 +3,10 @@ gas,fuel,11.2,EUR/MWh_th,Ariadne,
 oil,fuel,22.1982,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,5.7048,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump, investment, 3.319, EUR2020/kw_th, Ariadne,
-decentral ground-sourced heat pump, investment, 5.340, EUR2020/kw_th, Ariadne,
-electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
-HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
-HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
-HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
-HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,
+decentral air-sourced heat pump,investment,3.319,EUR2020/kw_th,Ariadne,
+decentral ground-sourced heat pump,investment,5.340,EUR2020/kw_th,Ariadne,
+electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
+HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
+HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
+HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
+HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,11.2,EUR/MWh_th,Ariadne,
 oil,fuel,22.1982,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,5.7048,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3319,EUR2020/kW_th,Ariadne database
-decentral ground-sourced heat pump,investment,5340,EUR2020/kW_th,Ariadne database
+decentral air-sourced heat pump,investment,3319,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf
+decentral ground-sourced heat pump,investment,5340,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -3,10 +3,10 @@ gas,fuel,11.2,EUR/MWh_th,Ariadne,
 oil,fuel,22.1982,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,5.7048,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3.319,EUR2020/kw_th,Ariadne,
-decentral ground-sourced heat pump,investment,5.340,EUR2020/kw_th,Ariadne,
-electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
-HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
-HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
-HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
-HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,
+decentral air-sourced heat pump,investment,3319,EUR2020/kW_th,Ariadne database
+decentral ground-sourced heat pump,investment,5340,EUR2020/kW_th,Ariadne database
+electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
+HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021
+HVDC overhead,investment,1000,EUR2020/MW/km,NEP2021
+HVDC submarine,investment,3250,EUR2020/MW/km,NEP2021

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -3,3 +3,10 @@ gas,fuel,11.2,EUR/MWh_th,Ariadne,
 oil,fuel,22.1982,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,5.7048,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
+decentral air-sourced heat pump, investment, 3.319, EUR2020/kw_th, Ariadne,
+decentral ground-sourced heat pump, investment, 5.340, EUR2020/kw_th, Ariadne,
+electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
+HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
+HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
+HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
+HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -3,3 +3,8 @@ gas,fuel,40,EUR/MWh_th,Ariadne,
 oil,fuel,32.9876,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,10.6694,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
+electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
+HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
+HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
+HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
+HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,40,EUR/MWh_th,Ariadne,
 oil,fuel,32.9876,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,10.6694,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
-HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
-HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
-HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
-HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,
+electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
+HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
+HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
+HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
+HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,40,EUR/MWh_th,Ariadne,
 oil,fuel,32.9876,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,10.6694,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3160,EUR2020/kW_th,Ariadne database
-decentral ground-sourced heat pump,investment,5162,EUR2020/kW_th,Ariadne database
+decentral air-sourced heat pump,investment,3160,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,5162,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -3,8 +3,10 @@ gas,fuel,40,EUR/MWh_th,Ariadne,
 oil,fuel,32.9876,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,10.6694,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
-HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
-HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
-HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
-HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,
+decentral air-sourced heat pump,investment,3160,EUR2020/kW_th,Ariadne database
+decentral ground-sourced heat pump,investment,5162,EUR2020/kW_th,Ariadne database
+electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
+HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021
+HVDC overhead,investment,1000,EUR2020/MW/km,NEP2021
+HVDC submarine,investment,3250,EUR2020/MW/km,NEP2021

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -3,8 +3,10 @@ gas,fuel,22.3,EUR/MWh_th,Ariadne,
 oil,fuel,38.821,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2056,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1083,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
-HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
-HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
-HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
-HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,
+decentral air-sourced heat pump,investment,3001,EUR2020/kW_th,Ariadne database
+decentral ground-sourced heat pump,investment,4984,EUR2020/kW_th,Ariadne database
+electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
+HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021
+HVDC overhead,investment,1000,EUR2020/MW/km,NEP2021
+HVDC submarine,investment,3250,EUR2020/MW/km,NEP2021

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -3,3 +3,8 @@ gas,fuel,22.3,EUR/MWh_th,Ariadne,
 oil,fuel,38.821,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2056,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1083,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
+electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
+HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
+HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
+HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
+HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.3,EUR/MWh_th,Ariadne,
 oil,fuel,38.821,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2056,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1083,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3001,EUR2020/kW_th,Ariadne database
-decentral ground-sourced heat pump,investment,4984,EUR2020/kW_th,Ariadne database
+decentral air-sourced heat pump,investment,3001,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,4984,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.3,EUR/MWh_th,Ariadne,
 oil,fuel,38.821,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2056,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1083,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
-HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
-HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
-HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
-HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,
+electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
+HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
+HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
+HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
+HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.4,EUR/MWh_th,Ariadne,
 oil,fuel,38.5629,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2601,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,900,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
-HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
-HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
-HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
-HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,
+electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
+HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
+HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
+HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
+HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.4,EUR/MWh_th,Ariadne,
 oil,fuel,38.5629,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2601,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,900,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,2922,EUR2020/kW_th,Ariadne database
-decentral ground-sourced heat pump,investment,4806,EUR2020/kW_th,Ariadne database
+decentral air-sourced heat pump,investment,2922,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,4806,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -3,8 +3,10 @@ gas,fuel,22.4,EUR/MWh_th,Ariadne,
 oil,fuel,38.5629,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2601,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,900,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
-HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
-HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
-HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
-HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,
+decentral air-sourced heat pump,investment,2922,EUR2020/kW_th,Ariadne database
+decentral ground-sourced heat pump,investment,4806,EUR2020/kW_th,Ariadne database
+electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
+HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021
+HVDC overhead,investment,1000,EUR2020/MW/km,NEP2021
+HVDC submarine,investment,3250,EUR2020/MW/km,NEP2021

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -3,3 +3,8 @@ gas,fuel,22.4,EUR/MWh_th,Ariadne,
 oil,fuel,38.5629,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2601,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,900,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
+electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
+HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
+HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
+HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
+HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -3,8 +3,10 @@ gas,fuel,22.6,EUR/MWh_th,Ariadne,
 oil,fuel,38.3564,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3036,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,717,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
-HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
-HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
-HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
-HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,
+decentral air-sourced heat pump,investment,2842,EUR2020/kW_th,Ariadne database
+decentral ground-sourced heat pump,investment,4628,EUR2020/kW_th,Ariadne database
+electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
+HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021
+HVDC overhead,investment,1000,EUR2020/MW/km,NEP2021
+HVDC submarine,investment,3250,EUR2020/MW/km,NEP2021

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.6,EUR/MWh_th,Ariadne,
 oil,fuel,38.3564,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3036,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,717,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,2842,EUR2020/kW_th,Ariadne database
-decentral ground-sourced heat pump,investment,4628,EUR2020/kW_th,Ariadne database
+decentral air-sourced heat pump,investment,2842,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,4628,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.6,EUR/MWh_th,Ariadne,
 oil,fuel,38.3564,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3036,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,717,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
-HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
-HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
-HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
-HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,
+electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
+HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
+HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
+HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
+HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -3,3 +3,8 @@ gas,fuel,22.6,EUR/MWh_th,Ariadne,
 oil,fuel,38.3564,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3036,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,717,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
+electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
+HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
+HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
+HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
+HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.8,EUR/MWh_th,Ariadne,
 oil,fuel,38.0983,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3472,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,533,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
-HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
-HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
-HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
-HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,
+electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
+HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
+HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
+HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
+HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -3,3 +3,8 @@ gas,fuel,22.8,EUR/MWh_th,Ariadne,
 oil,fuel,38.0983,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3472,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,533,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
+electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
+HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
+HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
+HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
+HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.8,EUR/MWh_th,Ariadne,
 oil,fuel,38.0983,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3472,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,533,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,2763,EUR2020/kW_th,Ariadne database
-decentral ground-sourced heat pump,investment,4450,EUR2020/kW_th,Ariadne database
+decentral air-sourced heat pump,investment,2763,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,4450,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -3,8 +3,10 @@ gas,fuel,22.8,EUR/MWh_th,Ariadne,
 oil,fuel,38.0983,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3472,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,533,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
-HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
-HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
-HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
-HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,
+decentral air-sourced heat pump,investment,2763,EUR2020/kW_th,Ariadne database
+decentral ground-sourced heat pump,investment,4450,EUR2020/kW_th,Ariadne database
+electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
+HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021
+HVDC overhead,investment,1000,EUR2020/MW/km,NEP2021
+HVDC submarine,investment,3250,EUR2020/MW/km,NEP2021

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.9,EUR/MWh_th,Ariadne,
 oil,fuel,37.8918,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.4016,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,350,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
-HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
-HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
-HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
-HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,
+electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
+HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
+HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
+HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
+HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.9,EUR/MWh_th,Ariadne,
 oil,fuel,37.8918,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.4016,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,350,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,2683,EUR2020/kW_th,Ariadne database
-decentral ground-sourced heat pump,investment,4272,EUR2020/kW_th,Ariadne database
+decentral air-sourced heat pump,investment,2683,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,4272,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -3,8 +3,10 @@ gas,fuel,22.9,EUR/MWh_th,Ariadne,
 oil,fuel,37.8918,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.4016,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,350,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-electricity distribution grid,investment,3000,EUR2020/kW,Ariadne,
-HVAC overhead,investment,736,EUR2020/MW/km,Ariadne,
-HVDC inverter pair,investment,600000,EUR2020/MW,Ariadne,
-HVDC overhead,investment,1000,EUR2020/MW/km,Ariadne,
-HVDC submarine,investment,3250,EUR2020/MW/km,Ariadne,
+decentral air-sourced heat pump,investment,2683,EUR2020/kW_th,Ariadne database
+decentral ground-sourced heat pump,investment,4272,EUR2020/kW_th,Ariadne database
+electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
+HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021
+HVDC overhead,investment,1000,EUR2020/MW/km,NEP2021
+HVDC submarine,investment,3250,EUR2020/MW/km,NEP2021

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -3,3 +3,8 @@ gas,fuel,22.9,EUR/MWh_th,Ariadne,
 oil,fuel,37.8918,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.4016,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,350,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
+electricity distribution grid, investment, 3000, EUR2020/kW, Ariadne,
+HVAC overhead, investment, 736, EUR2020/MW/km, Ariadne,
+HVDC inverter pair, investment, 600000, EUR2020/MW, Ariadne,
+HVDC overhead, investment, 1000, EUR2020/MW/km, Ariadne,
+HVDC submarine, investment, 3250, EUR2020/MW/km, Ariadne,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,7 +63,7 @@ countries: ['AT', 'BE', 'CH', 'CZ', 'DE', 'DK', 'FR', 'GB', 'LU', 'NL', 'NO', 'P
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
 enable:
-  retrieve: false # set to false once initial data is retrieved
+  retrieve: true # set to false once initial data is retrieved
   retrieve_cutout: false # set to false once initial data is retrieved
 clustering:
   focus_weights:
@@ -178,9 +178,9 @@ first_technology_occurrence:
 
 renewable:
   offwind-ac:
-    capacity_per_sqkm: 8
+    capacity_per_sqkm: 10
   offwind-dc:
-    capacity_per_sqkm: 8
+    capacity_per_sqkm: 10
 
 costs:
   version: v0.8.1

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -63,7 +63,7 @@ countries: ['AT', 'BE', 'CH', 'CZ', 'DE', 'DK', 'FR', 'GB', 'LU', 'NL', 'NO', 'P
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
 enable:
-  retrieve: true # set to false once initial data is retrieved
+  retrieve: false # set to false once initial data is retrieved
   retrieve_cutout: false # set to false once initial data is retrieved
 clustering:
   focus_weights:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -138,6 +138,7 @@ rule modify_prenetwork:
     params:
         enable_kernnetz=config["wasserstoff_kernnetz"]["enable"],
         costs=config["costs"],
+        max_hours=config["electricity"]["max_hours"],
     input:
         network=RESULTS
         + "prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -139,11 +139,12 @@ rule modify_prenetwork:
         enable_kernnetz=config["wasserstoff_kernnetz"]["enable"],
         costs=config["costs"],
         max_hours=config["electricity"]["max_hours"],
+        length_factor=config["lines"]["length_factor"],
     input:
         network=RESULTS
         + "prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
         wkn="resources/wasserstoff_kernnetz_elec_s{simpl}_{clusters}.csv",
-        costs=resources("costs_{planning_horizons}.csv"),
+        costs=resources("modified-costs_{planning_horizons}.csv"),
     output:
         network=RESULTS
         + "prenetworks-final/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -122,7 +122,10 @@ use rule prepare_sector_network from pypsaeur with:
 rule modify_cost_data:
     input:
         costs=resources("costs_{planning_horizons}.csv"),
-        modifications="ariadne-data/costs_{planning_horizons}-modifications.csv",
+        modifications=lambda w: (
+            "ariadne-data/costs_2019-modifications.csv"
+            if w.planning_horizons == "2020" and config["energy"]["energy_totals_year"] == 2019
+            else "ariadne-data/costs_{planning_horizons}-modifications.csv")
     output:
         resources("modified-costs_{planning_horizons}.csv"),
     resources:

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -16,6 +16,7 @@ from prepare_sector_network import (
     prepare_costs,
     lossy_bidirectional_links,
 )
+from add_electricity import load_costs, update_transmission_costs
 
 
 def first_technology_occurrence(n):
@@ -346,4 +347,14 @@ if __name__ == "__main__":
         wkn = pd.read_csv(fn, index_col=0)
         add_wasserstoff_kernnetz(n, wkn, costs)
         n.links.reversed = n.links.reversed.astype(float)
+
+    costs_loaded = load_costs(
+        snakemake.input.costs,
+        snakemake.params.costs,
+        snakemake.params.max_hours,
+        nyears,
+    )
+
+    update_transmission_costs(n, costs_loaded)
+
     n.export_to_netcdf(snakemake.output.network)

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -16,7 +16,7 @@ from prepare_sector_network import (
     prepare_costs,
     lossy_bidirectional_links,
 )
-from add_electricity import load_costs, update_transmission_costs
+from add_electricity import load_costs
 
 
 def first_technology_occurrence(n):
@@ -296,6 +296,35 @@ def unravel_oilbus(n):
         capital_cost=0.02,
     )
 
+def update_transmission_costs(n, costs, length_factor=1.0):
+    n.lines["capital_cost"] = (
+        n.lines["length"] * length_factor * costs.at["HVAC overhead", "capital_cost"]
+    )
+
+    if n.links.empty:
+        return
+    # get all DC links that are not the reverse links
+    dc_b = (n.links.carrier == "DC") & ~(n.links.index.str.contains("reverse"))
+
+    # If there are no dc links, then the 'underwater_fraction' column
+    # may be missing. Therefore we have to return here.
+    if n.links.loc[dc_b].empty:
+        return
+
+    costs = (
+        n.links.loc[dc_b, "length"]
+        * length_factor
+        * (
+            (1.0 - n.links.loc[dc_b, "underwater_fraction"])
+            * costs.at["HVDC overhead", "capital_cost"]
+            + n.links.loc[dc_b, "underwater_fraction"]
+            * costs.at["HVDC submarine", "capital_cost"]
+        )
+        + costs.at["HVDC inverter pair", "capital_cost"]
+    )
+    n.links.loc[dc_b, "capital_cost"] = costs
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         import os
@@ -313,6 +342,7 @@ if __name__ == "__main__":
             ll="v1.2",
             sector_opts="365H-T-H-B-I-A-solar+p3-linemaxext15",
             planning_horizons="2040",
+            run="KN2045_H2_v4"
         )
 
     logger.info("Adding Ariadne-specific functionality")
@@ -355,6 +385,7 @@ if __name__ == "__main__":
         nyears,
     )
 
-    update_transmission_costs(n, costs_loaded)
+    # change to NEP21 costs
+    update_transmission_costs(n, costs_loaded, snakemake.params.length_factor)
 
     n.export_to_netcdf(snakemake.output.network)

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -296,7 +296,7 @@ def unravel_oilbus(n):
         capital_cost=0.02,
     )
 
-def transmission_costs_NEP(n, costs, length_factor=1.0):
+def transmission_costs_from_modified_cost_data(n, costs, length_factor=1.0):
     # copying the the function update_transmission_costs from add_electricity
     # slight change to the function so it works in modify_prenetwork
     n.lines["capital_cost"] = (
@@ -388,6 +388,6 @@ if __name__ == "__main__":
     )
 
     # change to NEP21 costs
-    transmission_costs_NEP(n, costs_loaded, snakemake.params.length_factor)
+    transmission_costs_from_modified_cost_data(n, costs_loaded, snakemake.params.length_factor)
 
     n.export_to_netcdf(snakemake.output.network)

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -296,7 +296,9 @@ def unravel_oilbus(n):
         capital_cost=0.02,
     )
 
-def update_transmission_costs(n, costs, length_factor=1.0):
+def transmission_costs_NEP(n, costs, length_factor=1.0):
+    # copying the the function update_transmission_costs from add_electricity
+    # slight change to the function so it works in modify_prenetwork
     n.lines["capital_cost"] = (
         n.lines["length"] * length_factor * costs.at["HVAC overhead", "capital_cost"]
     )
@@ -386,6 +388,6 @@ if __name__ == "__main__":
     )
 
     # change to NEP21 costs
-    update_transmission_costs(n, costs_loaded, snakemake.params.length_factor)
+    transmission_costs_NEP(n, costs_loaded, snakemake.params.length_factor)
 
     n.export_to_netcdf(snakemake.output.network)


### PR DESCRIPTION
Because of the Covid pandemic, the prices for gas, coal and oil were low because of the decreased demand. Since we are using 2019 demand data from eurostat, the workflow now takes also the prices from 2019 into account.

There are also added heat pump values manually for 2019/2020:

|technology| investment costs|unit|
|---|---|---|
|decentral air-sourced heat pump| 3319| EUR2020/kW_th|
|decentral ground-sourced heat pump| 5340| EUR2020/kW_th|

The Network expansion costs are changed for all `planning_horizons`:

|technology| investment costs|unit|
|---|---|---|
|electricity distribution grid| 3000| EUR2020/kW|
|HVAC overhead|736 | EUR2020/MW/km|
|HVDC inverter pair| 600000| EUR2020/MW|
|HVDC overhead| 1000| EUR2020/MW/km|
|HVDC submarine| 3250| EUR2020/MW/km|

Note that the og table from Fabian Neumann included more data but the DEA data does not include `AC/DC underground` data. Since the `submarine` data is missing in NEP 21, the underground values are taken as substitute. 
| Paramter & unit          | PyPSA-Eur | NEP 23    | NEP 21 | ACER 23 average | ACER 23 Q3 | Vrana &  Härtel (2023) |
|--------------------------|-----------|-----------|--------|-----------------|------------|------------------------|
| AC overhead (€/MW/km)    | 442       | 1325-1384 | 736    | 371             | 481        | -                      |
| AC underground (€/MW/km) | -         | 4711      | 3386   | 771             | 821        | -                      |
| AC submarine (€/MW/km)   | -         | -         | -      | 1182            | 1488       | -                      |
| DC overhead (€/MW/km)    | 442       | -         | 1000   | 371             | 481        | -                      |
| DC underground (€/MW/km) | -         | 3300-3800 | 3250   | 771             | 821        | 870                    |
| DC submarine (€/MW/km)   | 1008      | -         | -      | 653             | 741        | 1159                   |
| DC inverter pair (€/kW)  | 166       | -         | 600    | 150             | 193        | -                      |

Compared to before the capital_cost of DC links are now ~ 3 times higher then before.