### PR TITLE
Trend Scenario 

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -27,6 +27,7 @@ iiasa_database:
     - FORECAST v1.0
     - DEMO v1
   scenarios:
+    # - CurrentPolicies
     - Trend
     - 8Gt_Bal_v3
     - 8Gt_Elec_v3

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,7 +5,7 @@
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   name:
-  - Trend
+  - CurrentPolicies
   - KN2045_Bal_v4
   - KN2045_Elec_v4
   - KN2045_H2_v4

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,9 +5,10 @@
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   name:
-  - KN2045_Bal_v4
-  - KN2045_Elec_v4
-  - KN2045_H2_v4
+  - KN2045_Trend_v4
+  # - KN2045_Bal_v4
+  # - KN2045_Elec_v4
+  # - KN2045_H2_v4
   # - KN2045plus_EasyRide
   # - KN2045plus_LowDemand
   # - KN2045minus_WorstCase
@@ -25,7 +26,8 @@ iiasa_database:
     - TIMES PanEU v1.0
     - FORECAST v1.0
     - DEMO v1
-  scenarios: 
+  scenarios:
+    - Trend
     - 8Gt_Bal_v3
     - 8Gt_Elec_v3
     - 8Gt_H2_v3

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,10 +5,10 @@
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
   name:
-  - KN2045_Trend_v4
-  # - KN2045_Bal_v4
-  # - KN2045_Elec_v4
-  # - KN2045_H2_v4
+  - Trend
+  - KN2045_Bal_v4
+  - KN2045_Elec_v4
+  - KN2045_H2_v4
   # - KN2045plus_EasyRide
   # - KN2045plus_LowDemand
   # - KN2045minus_WorstCase

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-Trend:
+CurrentPolicies:
 # Trend Szenario
 # Suggestion (Tom): "policy from 2030 is frozen"
 # conservative development after 2030

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -58,17 +58,17 @@ CurrentPolicies:
             2020: 48
             2025: 61
             2030: 86.5 # 75 % Wind-an-Land Law
-            2035: 117.75 # 75 % Wind-an-Land Law
-            2040: 120 # 75 % Wind-an-Land Law
-            2045: 120
+            2035: 86.5
+            2040: 86.5
+            2045: 86.5
         offwind:
           DE:
             2020: 7.77
             2025: 8
             2030: 22.5 # 75 % Wind-auf-See Law
-            2035: 30 # 75 % Wind-auf-See Law assuming at least 1/3 of difference reached in 2040
-            2040: 32.5 # 75 % Wind-auf-See Law
-            2045: 52.5 # 75 % Wind-auf-See Law
+            2035: 22.5
+            2040: 22.5
+            2045: 22.5
         solar:
           DE:
             2020: 59
@@ -76,9 +76,9 @@ CurrentPolicies:
             # assuming at least 1/3 of difference reached in 2025
             2025: 101 
             2030: 161.25 # 75 % PV strategy
-            2035: 231.75
-            2040: 300 # 75 % PV strategy
-            2045: 300
+            2035: 161.25
+            2040: 161.25
+            2045: 161.25
 
   # boundary condition of maximum volumes
   limits_volume_max:

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -39,46 +39,46 @@ CurrentPolicies:
     2020:
       DE: 0.728
     2025:
-      DE: 0.571
+      DE: 0.573
     2030:
-      DE: 0.396
+      DE: 0.401
     2035:
-      DE: 0.396 # 2030 value
+      DE: 0.401 # 2030 value
     2040:
-      DE: 0.396 # 2030 value
+      DE: 0.401 # 2030 value
     2045:
-      DE: 0.396 # 2030 value
+      DE: 0.401  # 2030 value
     2050:
-      DE: 0.396 # 2030 value
+      DE: 0.401  # 2030 value
 
   limits_capacity_min:
-      Generator:
-        onwind:
-          DE:
-            2020: 48
-            2025: 61
-            2030: 86.5 # 75 % Wind-an-Land Law
-            2035: 86.5
-            2040: 86.5
-            2045: 86.5
-        offwind:
-          DE:
-            2020: 7.77
-            2025: 8
-            2030: 22.5 # 75 % Wind-auf-See Law
-            2035: 22.5
-            2040: 22.5
-            2045: 22.5
-        solar:
-          DE:
-            2020: 59
+    Generator:
+      onwind:
+        DE:
+          2020: 48
+          2025: 61
+          2030: 86.5   # 75 % Wind-an-Land Law
+          2035: 86.5
+          2040: 86.5
+          2045: 86.5
+      offwind:
+        DE:
+          2020: 7.77
+          2025: 8
+          2030: 22.5   # 75 % Wind-auf-See Law
+          2035: 22.5
+          2040: 22.5
+          2045: 22.5
+      solar:
+        DE:
+          2020: 59
             # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW, 
             # assuming at least 1/3 of difference reached in 2025
-            2025: 101 
-            2030: 161.25 # 75 % PV strategy
-            2035: 161.25
-            2040: 161.25
-            2045: 161.25
+          2025: 101
+          2030: 161.25   # 75 % PV strategy
+          2035: 161.25
+          2040: 161.25
+          2045: 161.25
 
   # boundary condition of maximum volumes
   limits_volume_max:
@@ -134,44 +134,44 @@ CurrentPolicies:
       2020: 0.0047
       2025: 0.0611
       2030: 0.243
-      2035: 0.5199
-      2040: 0.74
-      2045: 0.8737
+      2035: 0.243
+      2040: 0.243
+      2045: 0.243
     land_transport_fuel_cell_share:
       2020: 0.004
       2025: 0.0362
       2030: 0.0667
-      2035: 0.0485
-      2040: 0.0252
-      2045: 0.0085
+      2035: 0.0667
+      2040: 0.0667
+      2045: 0.0667
     land_transport_ice_share:
       2020: 0.9913
       2025: 0.9027
       2030: 0.6903
-      2035: 0.4316
-      2040: 0.2348
-      2045: 0.1178
+      2035: 0.6903
+      2040: 0.6903
+      2045: 0.6903
     shipping_hydrogen_share:
       2020: 0.0
       2025: 0.0
       2030: 0.0238
-      2035: 0.0522
-      2040: 0.0802
-      2045: 0.1142
+      2035: 0.0238
+      2040: 0.0238
+      2045: 0.0238
     shipping_methanol_share:
       2020: 0.0
       2025: 0.0
       2030: 0.0
       2035: 0.0
-      2040: -0.0
+      2040: 0.0
       2045: 0.0
     shipping_oil_share:
       2020: 1.0
       2025: 1.0
       2030: 0.9762
-      2035: 0.9478
-      2040: 0.9198
-      2045: 0.8858
+      2035: 0.9762
+      2040: 0.9762
+      2045: 0.9762
 
 KN2045_Bal_v4:
 # Ausgewogener Mix an Technologien zur Dekarbonisierung der Sektoren
@@ -191,17 +191,17 @@ KN2045_Bal_v4:
     2020:
       DE: 0.728
     2025:
-      DE: 0.571
+      DE: 0.573
     2030:
-      DE: 0.396
+      DE: 0.401
     2035:
-      DE: 0.258
+      DE: 0.265
     2040:
-      DE: 0.118
+      DE: 0.135
     2045:
-      DE: -0.028
+      DE: -0.011
     2050:
-      DE: -0.024
+      DE: -0.017
 
   # boundary condition of maximum volumes
   limits_volume_max:
@@ -309,17 +309,17 @@ KN2045_Elec_v4:
     2020:
       DE: 0.728
     2025:
-      DE: 0.571
+      DE: 0.573
     2030:
-      DE: 0.396
+      DE: 0.401
     2035:
-      DE: 0.258
+      DE: 0.265
     2040:
-      DE: 0.118
+      DE: 0.135
     2045:
-      DE: -0.028
+      DE: -0.011
     2050:
-      DE: -0.024
+      DE: -0.017
 
   limits_volume_max:
     # constrain electricity import in TWh

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-KN2045_Trend_v4:
+Trend:
 # Trend Szenario
 # Suggestion (Tom): "policy from 2030 is frozen"
 # conservative development after 2030

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -10,7 +10,7 @@ CurrentPolicies:
 # fixing CO2 budget at 2030 value for 2035-2050
 # reducing VRE targets in 2030 to 75% of the target (following REMIND)
 # not forcing H2 production
-# orient transport transformation towards ALADIN (Fraunhofer model) results
+# orient transport transformation from REMod v1.0 (currently is DEMO)
 # industry transformation towards FORECAST results
 # consider not assuming Kernnetz
 
@@ -23,8 +23,8 @@ CurrentPolicies:
     enable: false
 
   iiasa_database:
-    # TODO: wait for REMod v1.0 to upload a Trend scenario
-    reference_scenario: Trend
+    # TODO: wait for REMod v1.0 to upload a first Trend scenario
+    reference_scenario: Trend # CurrentPolicies once it's renamed
 
   co2_budget:
     2020: 0.800 # 20% reduction by 2020

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -3,6 +3,167 @@
 #
 # SPDX-License-Identifier: MIT
 
+KN2045_Trend_v4:
+# Trend Szenario
+# Suggestion (Tom): "policy from 2030 is frozen"
+# conservative development after 2030
+# fixing CO2 budget at 2030 value for 2035-2050
+# reducing VRE targets in 2030 to 75% of the target (following REMIND)
+# not forcing H2 production
+# orient transport transformation towards ALADIN (Fraunhofer model) results
+# industry transformation towards FORECAST results
+# consider not assuming Kernnetz
+
+  clustering:
+    temporal:
+      resolution_sector: 365H
+
+  # Kernnetz is not assumed to be built
+  wasserstoff_kernnetz:
+    enable: false
+
+  iiasa_database:
+    # TODO: wait for REMod v1.0 to upload a Trend scenario
+    reference_scenario: Trend
+
+  co2_budget_national:
+    2020:
+      DE: 0.728
+    2025:
+      DE: 0.571
+    2030:
+      DE: 0.396
+    2035:
+      DE: 0.396 # 2030 value
+    2040:
+      DE: 0.396 # 2030 value
+    2045:
+      DE: 0.396 # 2030 value
+    2050:
+      DE: 0.396 # 2030 value
+
+  limits_capacity_min:
+      Generator:
+        onwind:
+          DE:
+            2020: 48
+            2025: 61
+            2030: 86.5 # 75 % Wind-an-Land Law
+            2035: 117.75 # 75 % Wind-an-Land Law
+            2040: 120 # 75 % Wind-an-Land Law
+            2045: 120
+        offwind:
+          DE:
+            2020: 7.77
+            2025: 8
+            2030: 22.5 # 75 % Wind-auf-See Law
+            2035: 30 # 75 % Wind-auf-See Law assuming at least 1/3 of difference reached in 2040
+            2040: 32.5 # 75 % Wind-auf-See Law
+            2045: 52.5 # 75 % Wind-auf-See Law
+        solar:
+          DE:
+            2020: 59
+            # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW, 
+            # assuming at least 1/3 of difference reached in 2025
+            2025: 101 
+            2030: 161.25 # 75 % PV strategy
+            2035: 231.75
+            2040: 300 # 75 % PV strategy
+            2045: 300
+
+  # boundary condition of maximum volumes
+  limits_volume_max:
+    # constrain electricity import in TWh
+    electricity_import:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 0
+        2035: 40
+        2040: 80
+        2045: 125
+    electrolysis:
+    # boundary condition lower?
+      DE:
+        2020: 0
+        2025: 5
+        2030: 45
+        2035: 130
+        2040: 215
+        2045: 300
+    h2_derivate_import:
+    # boundary condition lower?
+      DE:
+        2020: 0
+        2025: 0
+        2030: 10
+        2035: 105
+        2040: 200
+        2045: 300
+    h2_import:
+    # boundary condition lower?
+      DE:
+        2020: 0
+        2025: 5
+        2030: 15
+        2035: 115
+        2040: 220
+        2045: 325
+  limits_volume_min:
+    electrolysis:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 0
+        2035: 0
+        2040: 0
+        2045: 0
+  # sector boundary conditions
+  sector:
+  # read that in from REMod - Fraunhofer
+    land_transport_electric_share:
+      2020: 0.0047
+      2025: 0.0611
+      2030: 0.243
+      2035: 0.5199
+      2040: 0.74
+      2045: 0.8737
+    land_transport_fuel_cell_share:
+      2020: 0.004
+      2025: 0.0362
+      2030: 0.0667
+      2035: 0.0485
+      2040: 0.0252
+      2045: 0.0085
+    land_transport_ice_share:
+      2020: 0.9913
+      2025: 0.9027
+      2030: 0.6903
+      2035: 0.4316
+      2040: 0.2348
+      2045: 0.1178
+    shipping_hydrogen_share:
+      2020: 0.0
+      2025: 0.0
+      2030: 0.0238
+      2035: 0.0522
+      2040: 0.0802
+      2045: 0.1142
+    shipping_methanol_share:
+      2020: 0.0
+      2025: 0.0
+      2030: 0.0
+      2035: 0.0
+      2040: -0.0
+      2045: 0.0
+    shipping_oil_share:
+      2020: 1.0
+      2025: 1.0
+      2030: 0.9762
+      2035: 0.9478
+      2040: 0.9198
+      2045: 0.8858
+
 KN2045_Bal_v4:
 # Ausgewogener Mix an Technologien zur Dekarbonisierung der Sektoren
 # Breites Energieträgerportfolio in der Endenergie (Strom, Wasserstoff, synthetische Kraftstoffe)

--- a/config/scenarios.yaml
+++ b/config/scenarios.yaml
@@ -26,6 +26,15 @@ Trend:
     # TODO: wait for REMod v1.0 to upload a Trend scenario
     reference_scenario: Trend
 
+  co2_budget:
+    2020: 0.800 # 20% reduction by 2020
+    2025: 0.600
+    2030: 0.450 # 55% reduction by 2030 (Ff55)
+    2035: 0.450 # stagnation for the Trend scenario
+    2040: 0.450
+    2045: 0.450
+    2050: 0.450
+
   co2_budget_national:
     2020:
       DE: 0.728

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -239,6 +239,7 @@ rule build_scenarios:
     params:
         iiasa_scenario=config["iiasa_database"]["reference_scenario"],
         scenario_name=config["run"]["name"],
+        years=config["scenario"]["planning_horizons"],
     input:
         ariadne_database=resources("ariadne_database.csv"),
         scenario_yaml=config["run"]["scenarios"]["file"],

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -121,14 +121,18 @@ def write_to_scenario_yaml(
     }
 
     for scenario in scenarios:
-        for key in mapping_transport.keys():
+        for key, sector_mapping in mapping_transport.items():
             for year in transport_share.columns:
-                config[scenario]["sector"][mapping_transport[key]][year] = round(transport_share.loc[key, year].item(), 4)
-        for key in mapping_navigation.keys():
+                target_year = 2030 if scenario == "CurrentPolicies" and int(year) > 2030 else year
+                config[scenario]["sector"][sector_mapping][year] = round(transport_share.loc[key, target_year].item(), 4)
+        for key, sector_mapping in mapping_navigation.items():
             for year in naval_share.columns:
-                config[scenario]["sector"][mapping_navigation[key]][year] = round(naval_share.loc[key, year].item(), 4)
+                target_year = 2030 if scenario == "CurrentPolicies" and int(year) > 2030 else year
+                config[scenario]["sector"][sector_mapping][year] = round(naval_share.loc[key, target_year].item(), 4)
+
         for year, target in ksg_target_fractions.items():
-            config[scenario]["co2_budget_national"][year]["DE"] = target
+            target_value = float(ksg_target_fractions[2030]) if year > 2030 and scenario == "CurrentPolicies" else target
+            config[scenario]["co2_budget_national"][year]["DE"] = target_value
 
     # write back to yaml file
     yaml.dump(config, file_path)
@@ -159,13 +163,12 @@ if __name__ == "__main__":
         "Deutschland"]
 
     ksg_target_fractions = get_ksg_targets(df.loc["REMIND-EU v1.1"])
-    planning_horizons = [2020, 2025, 2030, 2035, 2040, 2045, 2050]
+    planning_horizons = snakemake.params.years
     transport_share, naval_share = get_shares(df, planning_horizons)
 
     scenarios = snakemake.params.scenario_name
 
     filename = snakemake.input.scenario_yaml
-
 
     write_to_scenario_yaml(
         filename, scenarios, transport_share, naval_share, ksg_target_fractions)


### PR DESCRIPTION
This PR provides the configurations for a Trend scenario. Since the [Modellierungsprotokoll](https://docs.google.com/document/d/10V6o-1vPECYu5UiEi4alYS8r-CXqZSRKqJkAGKt1N0Y/edit#heading=h.scs40dks0x32) is quite vague the policy from 2030 is frozen and the following assumptions are made
- the CO2 budget is fixed at the 2030 value for 2035-2050
- the minimum Germna VRE targets are reduced to  75 % of the political targets
-  there is no forced H2 production
- the Kernnetz is not built
- the transport sector is oriented towards the Fraunhofer ReMod model 
- the industry transformation is oriented towards the FORECAST model

Open issues:

- [ ] There is no `Trend` scenario from the ReMod model in the database yet
Using [DEMOv1.0](https://www.dlr.de/vf/desktopdefault.aspx/tabid-12751/22270_read-50064/) which should be sufficient