### PR TITLE
Add mastr chps

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -173,10 +173,9 @@ rule modify_existing_heating:
 
 rule retrieve_mastr:
     input:
-        HTTP.remote(
+        storage(
             "https://zenodo.org/records/8225106/files/bnetza_open_mastr_2023-08-08_B.zip",
             keep_local=True,
-            static=True,
         ),
     params:
         "data/mastr",
@@ -191,21 +190,20 @@ rule build_existing_chp_de:
     input:
         mastr_biomass="data/mastr/bnetza_open_mastr_2023-08-08_B_biomass.csv",
         mastr_combustion="data/mastr/bnetza_open_mastr_2023-08-08_B_combustion.csv",
-        plz_mapping=HTTP.remote(
+        plz_mapping=storage(
             "https://raw.githubusercontent.com/WZBSocialScienceCenter/plz_geocoord/master/plz_geocoord.csv",
             keep_local=True,
-            static=True,
         ),
-        busmap=RESOURCES + "networks/base.nc",
+        busmap=resources("networks/base.nc"),
     output:
-        german_chp=RESOURCES + "german_chp.csv",
+        german_chp=resources("german_chp.csv"),
     script:
         "scripts/build_existing_chp_de.py"
 
 use rule add_existing_baseyear from pypsaeur with:
     input:
         **rules.add_existing_baseyear.input,
-        custom_powerplants=RESOURCES + "german_chp.csv",
+        custom_powerplants=resources("german_chp.csv"),
 
 use rule build_existing_heating_distribution from pypsaeur with:
     input:


### PR DESCRIPTION
- Changed snakefile to retrieve and reference data in the new way (storage and resources functions) and adapted the input `plz_mapping` in `build_existing_chp_de.py` accordingly
- Changed the pointer to the changes made in PR of submodule (https://github.com/PyPSA/pypsa-eur/pull/907)
- As a result, backtesting the model for 2020 can yield a more accurate central heat  supply mix. However, this is only the case if the model is additionally restricted to not expand gas boilers (or gas boilers, heat pumps and resistive heaters) in 2020 (as done in `prepare_sector_network.py` in https://github.com/PyPSA/pypsa-eur/pull/907/commits/9219cb9ef39207943bdfc84437fead6ae222348b). Without this restriction the majority of the CHP fleet  (gas, solid biomass) is not dispatched due to their high variable costs (CHP operation + fuel).

Without restriction:
![urban_central_heat_2020_w_gas_boilers](https://github.com/PyPSA/pypsa-ariadne/assets/124347782/3c08c366-d232-41e8-b76b-958fe24dad83)

With restriction:
a) restricting gas boilers
![urban_central_heat_2020_wo_gas_boilers](https://github.com/PyPSA/pypsa-ariadne/assets/124347782/bab798df-78f1-4606-9a98-7dee87455b92)

b) restricting gas boilers, air-sourced heat pumps, and resistive heaters
![urban_central_heat_2020_wo_boilershprh](https://github.com/PyPSA/pypsa-ariadne/assets/124347782/b442f437-f04f-4e2d-a2d0-138cfca8ad64)


Validation Source (AGFW):
![AGFW_Fernwärme_2020](https://github.com/PyPSA/pypsa-ariadne/assets/124347782/1dc38c48-febc-4098-a497-6d22ddd9fd9f)
https://www.agfw.de/energiewirtschaft-recht-politik/energiewende-politik/ueberblick-fakten-und-antworten-zu-fernwaerme

 