### PR TITLE
Latest investment costs for heat pumps

### DIFF
--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,16.0,EUR/MWh_th,Ariadne,
 oil,fuel,33.2457,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.7391,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3319,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf
-decentral ground-sourced heat pump,investment,5340,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf
+decentral air-sourced heat pump,investment,1693,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
+decentral ground-sourced heat pump,investment,2788,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,11.2,EUR/MWh_th,Ariadne,
 oil,fuel,22.1982,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,5.7048,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3319,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf
-decentral ground-sourced heat pump,investment,5340,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf
+decentral air-sourced heat pump,investment,1693,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
+decentral ground-sourced heat pump,investment,2788,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,40,EUR/MWh_th,Ariadne,
 oil,fuel,32.9876,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,10.6694,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3160,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
-decentral ground-sourced heat pump,investment,5162,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral air-sourced heat pump,investment,1612,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,2695,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.3,EUR/MWh_th,Ariadne,
 oil,fuel,38.821,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2056,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1083,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,3001,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
-decentral ground-sourced heat pump,investment,4984,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral air-sourced heat pump,investment,1531,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,2602,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.4,EUR/MWh_th,Ariadne,
 oil,fuel,38.5629,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.2601,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,900,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,2922,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
-decentral ground-sourced heat pump,investment,4806,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral air-sourced heat pump,investment,1490,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,2509,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.6,EUR/MWh_th,Ariadne,
 oil,fuel,38.3564,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3036,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,717,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,2842,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
-decentral ground-sourced heat pump,investment,4628,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral air-sourced heat pump,investment,1450,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,2416,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.8,EUR/MWh_th,Ariadne,
 oil,fuel,38.0983,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.3472,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,533,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,2763,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
-decentral ground-sourced heat pump,investment,4450,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral air-sourced heat pump,investment,1409,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,2323,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -3,8 +3,8 @@ gas,fuel,22.9,EUR/MWh_th,Ariadne,
 oil,fuel,37.8918,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
 coal,fuel,6.4016,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,350,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
-decentral air-sourced heat pump,investment,2683,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
-decentral ground-sourced heat pump,investment,4272,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf and cost reduction from DEA
+decentral air-sourced heat pump,investment,1369,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
+decentral ground-sourced heat pump,investment,2230,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,3000,EUR2020/kW,NEP2021
 HVAC overhead,investment,736,EUR2020/MW/km,NEP2021
 HVDC inverter pair,investment,600000,EUR2020/MW,NEP2021


### PR DESCRIPTION
Kudos to @lisazeyen 

"
# Heat pump investment costs
## Current assumptions
- investmet costs for Single-Family House and Altbau
- typical size 10 kW_th per heat pump
- air-sourced (Luft-Wasser) 3319 Eur-2024/kW, ground-sourced (Sole-Wasser) 5340 Eur-2024/kW

These investment costs are in Eur-2024 and should be discounted to Eur-2020 -> assume inflation rate 0.5% (2020), 3.1% (2021), 7.9% (2022) und 6.5% (2023) an -> ~0.84*investment_cost_2024

 [source](https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf)

- also contains Multi-Family-House assumptions (22 kW_th per unit)
- air sourced 3029 Eur-2024/kW, ground sourced ~4252 Eur-2024/kW

[BDEW-Heizkostenvergleich Altbau 2021](https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf) (Original source for Ariadne)
- assume old house with  old gas boiler installed, heat pump + Durchlauferhitzer for warm water
- air sourced heat pump: SFH (p.17 EFH_08) 2107 Eur-2021/kW, MFH (p.23 FH_08) 2074 Eur/kW
- ground sourced (Sole-Wasser-WP): SFH (p.18 EFH_14) 3832 Eur-2021/kW, MFH (p.23 FH_10) 3051 Eur/kW

I assume it is Eur-2021 but it is no where stated
Similar values for houses with existing oil boilers
Includes costs of heating area/low-intensity measures of around 5000 euros per heat pump, costs include VAT

Check heat pump installers
[thermondo](https://www.thermondo.de/info/rat/waermepumpe/waermepumpe-kosten/), [enpal](https://www.enpal.de/waermepumpe/kosten) 

current costs around 2000-3000 Eur-2024/kW for air sourced and 1200-4500 Eur-2024/kW for ground-sourced heat pumps depending on the insulation of the building

DEA update (not integrated in technology-data)
- existing SFH, 7 kW heat pump, air sourced ~1564 Eur-2020/kW, ground sourced 2072 Eur-2020/kW
- existing Apartment, 320 kW heat pump, air sourced 688 Eur-2020/kW, ground sourced 641 Eur-2020/kW
- Since about 50% of the costs are for installation and there is learning on that as well, I excpect the German costs to be higher. This is also the reason why investment cost decrease so strongly with apartment blocks (160-320 kW heat pumps)

## Conclusion
take BDEW costs from original [source](https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf), heat pump + Durchlauferhitzer + small necessary changes to heating system, mean value of SFH and MFH, discount back to Eur-2020 and reduce VAT (19%) since this is not included in DEA cost assumptions
so it would be

- air sourced heat pump (2107+2074)/2*0.81=1693 Eur-2021/kW
- ground sourced heat pump (3832+3051)/2*0.81=2788 Eur-2021/kW
"