### PR TITLE
Add config for NEP2021 and NEP2023 cost data

### DIFF
--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -5,8 +5,10 @@ coal,fuel,6.7391,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1685,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
-electricity distribution grid,investment,2985,EUR2020/kW,NEP2021
+electricity distribution grid,investment,2985,EUR2020/kW,NEP2021+NEP2023
 HVAC overhead,investment,732,EUR2020/MW/km,NEP2021
-HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021
-HVDC overhead,investment,995,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
+HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
+HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -5,8 +5,10 @@ coal,fuel,5.7048,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1685,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
-electricity distribution grid,investment,2985,EUR2020/kW,NEP2021
+electricity distribution grid,investment,2985,EUR2020/kW,NEP2021+NEP2023
 HVAC overhead,investment,732,EUR2020/MW/km,NEP2021
-HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021
-HVDC overhead,investment,995,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
+HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
+HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -5,8 +5,10 @@ coal,fuel,10.6694,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1604,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2682,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
-electricity distribution grid,investment,2985,EUR2020/kW,NEP2021
+electricity distribution grid,investment,2985,EUR2020/kW,NEP2021+NEP2023
 HVAC overhead,investment,732,EUR2020/MW/km,NEP2021
-HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021
-HVDC overhead,investment,995,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
+HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
+HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -5,8 +5,10 @@ coal,fuel,6.2056,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1083,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1523,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2589,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
-electricity distribution grid,investment,2985,EUR2020/kW,NEP2021
+electricity distribution grid,investment,2985,EUR2020/kW,NEP2021+NEP2023
 HVAC overhead,investment,732,EUR2020/MW/km,NEP2021
-HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021
-HVDC overhead,investment,995,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
+HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
+HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -5,8 +5,10 @@ coal,fuel,6.2601,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,900,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1483,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2497,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
-electricity distribution grid,investment,2985,EUR2020/kW,NEP2021
+electricity distribution grid,investment,2985,EUR2020/kW,NEP2021+NEP2023
 HVAC overhead,investment,732,EUR2020/MW/km,NEP2021
-HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021
-HVDC overhead,investment,995,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
+HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
+HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -5,8 +5,10 @@ coal,fuel,6.3036,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,717,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1442,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2404,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
-electricity distribution grid,investment,2985,EUR2020/kW,NEP2021
+electricity distribution grid,investment,2985,EUR2020/kW,NEP2021+NEP2023
 HVAC overhead,investment,732,EUR2020/MW/km,NEP2021
-HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021
-HVDC overhead,investment,995,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
+HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
+HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -5,8 +5,10 @@ coal,fuel,6.3472,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,533,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1402,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2312,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
-electricity distribution grid,investment,2985,EUR2020/kW,NEP2021
+electricity distribution grid,investment,2985,EUR2020/kW,NEP2021+NEP2023
 HVAC overhead,investment,732,EUR2020/MW/km,NEP2021
-HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021
-HVDC overhead,investment,995,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
+HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
+HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -5,8 +5,10 @@ coal,fuel,6.4016,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,350,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1362,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2219,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
-electricity distribution grid,investment,2985,EUR2020/kW,NEP2021
+electricity distribution grid,investment,2985,EUR2020/kW,NEP2021+NEP2023
 HVAC overhead,investment,732,EUR2020/MW/km,NEP2021
-HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021
-HVDC overhead,investment,995,EUR2020/MW/km,NEP2021
+HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
+HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
+HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,11 +4,11 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: "20240521fixshared"
+  prefix: "2024_05_22_NEP2023_costs"
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
-  - KN2045_Elec_v4
+  # - KN2045_Elec_v4
   # - KN2045_H2_v4
   # - KN2045plus_EasyRide
   # - KN2045plus_LowDemand
@@ -183,6 +183,7 @@ costs:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
+  solar_thermal: false
   district_heating:
     potential: 0.4
     progress:

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -32,6 +32,7 @@ CurrentPolicies:
 
   costs:
     horizon: "mean"
+    NEP: 2023
 
   limits_capacity_min:
     Generator:
@@ -124,6 +125,7 @@ KN2045_Bal_v4:
 
   costs:
     horizon: "mean"
+    NEP: 2021
 
   # boundary condition of maximum volumes
   limits_volume_max:
@@ -180,6 +182,7 @@ KN2045_Elec_v4:
 
   costs:
     horizon: "mean"
+    NEP: 2021
 
   limits_volume_max:
     # constrain electricity import in TWh
@@ -235,6 +238,7 @@ KN2045_H2_v4:
 
   costs:
     horizon: "mean"
+    NEP: 2021
 
   limits_volume_max:
     # constrain electricity import in TWh
@@ -293,6 +297,7 @@ KN2045plus_EasyRide:
 
   costs:
     horizon: "optimist"
+    NEP: 2021
 
   # boundary condition of maximum volumes
   limits_volume_max: # following the Bal scenario
@@ -373,6 +378,7 @@ KN2045plus_LowDemand:
 
   costs:
     horizon: "optimist"
+    NEP: 2021
 
   # boundary condition of maximum volumes
   limits_volume_max: # Half of the Bal scenario
@@ -465,6 +471,7 @@ KN2045minus_WorstCase:
 
   costs:
     horizon: "pessimist"
+    NEP: 2023
 
   # boundary condition of maximum volumes
   limits_volume_max: # Half of the Bal scenario
@@ -545,6 +552,7 @@ KN2045minus_SupplyFocus:
 
   costs:
     horizon: "pessimist"
+    NEP: 2023
 
   co2_budget:
     2020: 0.800 # 20% reduction by 2020

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -33,7 +33,7 @@ CurrentPolicies:
   costs:
     horizon: "mean"
     NEP: 2023
-    transmission: "uc" # either overhead line ("ohl") or underground cable ("uc")
+    transmission: "underground" # either overhead line ("overhead") or underground cable ("underground")
 
   limits_capacity_min:
     Generator:
@@ -127,7 +127,7 @@ KN2045_Bal_v4:
   costs:
     horizon: "mean"
     NEP: 2021
-    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
+    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
 
   # boundary condition of maximum volumes
   limits_volume_max:
@@ -185,7 +185,7 @@ KN2045_Elec_v4:
   costs:
     horizon: "mean"
     NEP: 2021
-    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
+    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
 
   limits_volume_max:
     # constrain electricity import in TWh
@@ -242,7 +242,7 @@ KN2045_H2_v4:
   costs:
     horizon: "mean"
     NEP: 2021
-    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
+    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
 
   limits_volume_max:
     # constrain electricity import in TWh
@@ -302,7 +302,7 @@ KN2045plus_EasyRide:
   costs:
     horizon: "optimist"
     NEP: 2021
-    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
+    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
 
   # boundary condition of maximum volumes
   limits_volume_max: # following the Bal scenario
@@ -384,7 +384,7 @@ KN2045plus_LowDemand:
   costs:
     horizon: "optimist"
     NEP: 2021
-    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
+    transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
 
   # boundary condition of maximum volumes
   limits_volume_max: # Half of the Bal scenario
@@ -478,7 +478,7 @@ KN2045minus_WorstCase:
   costs:
     horizon: "pessimist"
     NEP: 2023
-    transmission: "uc" # either overhead line ("ohl") or underground cable ("uc")
+    transmission: "underground" # either overhead line ("overhead") or underground cable ("underground")
 
   # boundary condition of maximum volumes
   limits_volume_max: # Half of the Bal scenario
@@ -560,7 +560,7 @@ KN2045minus_SupplyFocus:
   costs:
     horizon: "pessimist"
     NEP: 2023
-    transmission: "uc" # either overhead line ("ohl") or underground cable ("uc")
+    transmission: "underground" # either overhead line ("overhead") or underground cable ("underground")
 
   co2_budget:
     2020: 0.800 # 20% reduction by 2020

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -33,6 +33,7 @@ CurrentPolicies:
   costs:
     horizon: "mean"
     NEP: 2023
+    transmission: "uc" # either overhead line ("ohl") or underground cable ("uc")
 
   limits_capacity_min:
     Generator:
@@ -126,6 +127,7 @@ KN2045_Bal_v4:
   costs:
     horizon: "mean"
     NEP: 2021
+    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
 
   # boundary condition of maximum volumes
   limits_volume_max:
@@ -183,6 +185,7 @@ KN2045_Elec_v4:
   costs:
     horizon: "mean"
     NEP: 2021
+    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
 
   limits_volume_max:
     # constrain electricity import in TWh
@@ -239,6 +242,7 @@ KN2045_H2_v4:
   costs:
     horizon: "mean"
     NEP: 2021
+    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
 
   limits_volume_max:
     # constrain electricity import in TWh
@@ -298,6 +302,7 @@ KN2045plus_EasyRide:
   costs:
     horizon: "optimist"
     NEP: 2021
+    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
 
   # boundary condition of maximum volumes
   limits_volume_max: # following the Bal scenario
@@ -379,6 +384,7 @@ KN2045plus_LowDemand:
   costs:
     horizon: "optimist"
     NEP: 2021
+    transmission: "ohl" # either overhead line ("ohl") or underground cable ("uc")
 
   # boundary condition of maximum volumes
   limits_volume_max: # Half of the Bal scenario
@@ -472,6 +478,7 @@ KN2045minus_WorstCase:
   costs:
     horizon: "pessimist"
     NEP: 2023
+    transmission: "uc" # either overhead line ("ohl") or underground cable ("uc")
 
   # boundary condition of maximum volumes
   limits_volume_max: # Half of the Bal scenario
@@ -553,6 +560,7 @@ KN2045minus_SupplyFocus:
   costs:
     horizon: "pessimist"
     NEP: 2023
+    transmission: "uc" # either overhead line ("ohl") or underground cable ("uc")
 
   co2_budget:
     2020: 0.800 # 20% reduction by 2020

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -112,6 +112,7 @@ rule modify_cost_data:
         file_path="ariadne-data/costs/",
         file_name="costs_{planning_horizons}.csv",
         cost_horizon=config_provider("costs", "horizon"),
+        NEP=config_provider("costs", "NEP"),
     input:
         modifications=lambda w: (
             "ariadne-data/costs_2019-modifications.csv"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -141,6 +141,7 @@ rule modify_prenetwork:
         H2_transmission_efficiency=config_provider("sector", "transmission_efficiency", "H2 pipeline"),
         H2_retrofit=config_provider("sector", "H2_retrofit"),
         H2_retrofit_capacity_per_CH4=config_provider("sector", "H2_retrofit_capacity_per_CH4"),
+        transmission_costs=config_provider("costs", "transmission"),
     input:
         network=RESULTS
         + "prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",

--- a/workflow/scripts/modify_cost_data.py
+++ b/workflow/scripts/modify_cost_data.py
@@ -58,6 +58,14 @@ if __name__ == "__main__":
         f"costs_{new_year}-modifications.csv", 
         snakemake.input.modifications)
     modifications = pd.read_csv(new_filename, index_col=[0, 1]).sort_index()
+    if snakemake.params.NEP == 2021:
+        modifications = modifications.query("source != 'NEP2023")
+    elif snakemake.params.NEP == 2023:
+        modifications = modifications.query("source != 'NEP2021")
+    else:
+        logger.warning(f"NEP year {snakemake.params.NEP} is not in modifications file. Falling back to NEP2021.")
+        modifications = modifications.query("source != 'NEP2023")
+
     costs.loc[modifications.index] = modifications
 
     print(costs.loc[modifications.index])

--- a/workflow/scripts/modify_cost_data.py
+++ b/workflow/scripts/modify_cost_data.py
@@ -59,12 +59,12 @@ if __name__ == "__main__":
         snakemake.input.modifications)
     modifications = pd.read_csv(new_filename, index_col=[0, 1]).sort_index()
     if snakemake.params.NEP == 2021:
-        modifications = modifications.query("source != 'NEP2023")
+        modifications = modifications.query("source != 'NEP2023'")
     elif snakemake.params.NEP == 2023:
-        modifications = modifications.query("source != 'NEP2021")
+        modifications = modifications.query("source != 'NEP2021'")
     else:
         logger.warning(f"NEP year {snakemake.params.NEP} is not in modifications file. Falling back to NEP2021.")
-        modifications = modifications.query("source != 'NEP2023")
+        modifications = modifications.query("source != 'NEP2023'")
 
     costs.loc[modifications.index] = modifications
 

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -314,11 +314,9 @@ def transmission_costs_from_modified_cost_data(n, costs, transmission, length_fa
     if n.links.loc[dc_b].empty:
         return
 
-    if transmission == "ohl":
-        # overhead line costs are assumed for links
+    if transmission == "overhead":
         links_costs = "HVDC overhead"
-    elif transmission == "uc":
-        # underground cable costs are assumed and links
+    elif transmission == "underground":
         links_costs = "HVDC submarine"
 
     costs = (

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -296,9 +296,10 @@ def unravel_oilbus(n):
           )
 
 
-def transmission_costs_from_modified_cost_data(n, costs, length_factor=1.0):
+def transmission_costs_from_modified_cost_data(n, costs, transmission, length_factor=1.0):
     # copying the the function update_transmission_costs from add_electricity
     # slight change to the function so it works in modify_prenetwork
+
     n.lines["capital_cost"] = (
         n.lines["length"] * length_factor * costs.at["HVAC overhead", "capital_cost"]
     )
@@ -313,12 +314,19 @@ def transmission_costs_from_modified_cost_data(n, costs, length_factor=1.0):
     if n.links.loc[dc_b].empty:
         return
 
+    if transmission == "ohl":
+        # overhead line costs are assumed for links
+        links_costs = "HVDC overhead"
+    elif transmission == "uc":
+        # underground cable costs are assumed and links
+        links_costs = "HVDC submarine"
+
     costs = (
         n.links.loc[dc_b, "length"]
         * length_factor
         * (
             (1.0 - n.links.loc[dc_b, "underwater_fraction"])
-            * costs.at["HVDC overhead", "capital_cost"]
+            * costs.at[links_costs, "capital_cost"]
             + n.links.loc[dc_b, "underwater_fraction"]
             * costs.at["HVDC submarine", "capital_cost"]
         )
@@ -389,6 +397,6 @@ if __name__ == "__main__":
     )
 
     # change to NEP21 costs
-    transmission_costs_from_modified_cost_data(n, costs_loaded, snakemake.params.length_factor)
+    transmission_costs_from_modified_cost_data(n, costs_loaded, snakemake.params.transmission_costs, snakemake.params.length_factor)
 
     n.export_to_netcdf(snakemake.output.network)


### PR DESCRIPTION
Adressing https://github.com/PyPSA/pypsa-ariadne/issues/82
This PR adds the `config[costs][NEP]` which can be set to `2021` or `2023`.
Note that the following costs are available:
| Paramter & unit          | NEP 23    | NEP 21 |
|--------------------------|-----------|-----------|
| AC overhead (€/MW/km)    | 1325-1384 | 736    |
| AC underground (€/MW/km) |4711      | 3386   |
| AC submarine (€/MW/km)   | -         | -      |
| DC overhead (€/MW/km)    |  -         | 1000   | 
| DC underground (€/MW/km) |3300-3800 | 3250   |
| DC submarine (€/MW/km)   |  -         | -      |
| DC inverter pair (€/kW)  |-         | 600    |

To convert the cost data to €2020 the following discount rates are used:
inflation rate 0.5% (2020), 3.1% (2021), 7.9% (2022) -> ~0.89686*investment_cost_2023

Since there are missing some values from in the NEP2023, the costs from NEP2021 are assumed to hold true for the future.

In `modify_prenetwork` new costs are assigned to lines and links. Depending on the `config[costs][transmission]` either overhead line or underground cable are assumed for HVDC connections.
