### PR TITLE
add carbon component for coal, gas and oil in 2020 and 2025

### DIFF
--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -1,7 +1,7 @@
 technology,parameter,value,unit,source,further description
-gas,fuel,11.2,EUR/MWh_th,Ariadne,
-oil,fuel,22.1982,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
-coal,fuel,5.7048,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
+gas,fuel,16.15,EUR/MWh_th,Ariadne,"plus carbon add on of 10.1725 €/MWh"
+oil,fuel,28.626,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh (plus carbon add on of 6.4275 €/MWh)"
+coal,fuel,14.107,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh (plus carbon add on of 8.4025 €/MWh)"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1685,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
@@ -12,3 +12,5 @@ HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
 HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+lignite,fuel,13.471,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 10 USD/t.  (plus carbon ad don of 10.1725 €/MWh"
+

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -1,7 +1,7 @@
 technology,parameter,value,unit,source,further description
-gas,fuel,16.15,EUR/MWh_th,Ariadne,"plus carbon add on of 10.1725 €/MWh"
-oil,fuel,28.626,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh (plus carbon add on of 6.4275 €/MWh)"
-coal,fuel,14.107,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh (plus carbon add on of 8.4025 €/MWh)"
+gas,fuel,11.2,EUR/MWh_th,Ariadne,
+oil,fuel,22.1982,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,5.7048,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1685,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
@@ -12,5 +12,3 @@ HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
 HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
-lignite,fuel,13.471,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 10 USD/t.  (plus carbon ad don of 10.1725 €/MWh"
-

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -1,7 +1,7 @@
 technology,parameter,value,unit,source,further description
-gas,fuel,51.88,EUR/MWh_th,Ariadne,"plus carbon add-on of 11.88 €/MWh €/MWh"
-oil,fuel,48.4136,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh (plus carbon add-on of 15.426 €/MWh)"
-coal,fuel,30.8354,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh (plus carbon add-on of 20.166 €/MWh)"
+gas,fuel,40,EUR/MWh_th,Ariadne,
+oil,fuel,32.9876,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
+coal,fuel,10.6694,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
 electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1604,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2682,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
@@ -12,5 +12,3 @@ HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
 HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
-lignite,fuel,27.7125,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 10 USD/t.  (plus carbon ad don of 24.414 €/MWh"
-

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -1,7 +1,7 @@
 technology,parameter,value,unit,source,further description
-gas,fuel,40,EUR/MWh_th,Ariadne,
-oil,fuel,32.9876,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh"
-coal,fuel,10.6694,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh"
+gas,fuel,51.88,EUR/MWh_th,Ariadne,"plus carbon add-on of 11.88 €/MWh €/MWh"
+oil,fuel,48.4136,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1bbl = 1.6998MWh (plus carbon add-on of 15.426 €/MWh)"
+coal,fuel,30.8354,EUR2020/MWh,Ariadne,"$2020 = 0.8775 EUR2020, 1t = 8.06 MWh (plus carbon add-on of 20.166 €/MWh)"
 electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW upper limit 2020 to 2050"
 decentral air-sourced heat pump,investment,1604,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2682,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
@@ -12,3 +12,5 @@ HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
 HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+lignite,fuel,27.7125,EUR/MWh_th,"DIW (2013): Current and propsective costs of electricity generation until 2050, http://hdl.handle.net/10419/80348 , pg. 80 text below figure 10, accessed: 2023-12-14.","Based on IEA 2011 data, 10 USD/t.  (plus carbon ad don of 24.414 €/MWh"
+

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -328,3 +328,7 @@ pypsa_eur:
   - PHS
   - hydro
   Store: []
+
+co2_price_add_on_fossils:
+  2020: 25 
+  2025: 60

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -115,6 +115,8 @@ rule modify_cost_data:
         file_name="costs_{planning_horizons}.csv",
         cost_horizon=config_provider("costs", "horizon"),
         NEP=config_provider("costs", "NEP"),
+        planning_horizons=config_provider("scenario", "planning_horizons"),
+        co2_price_add_on_fossils = config_provider("co2_price_add_on_fossils"),
     input:
         modifications=lambda w: (
             "ariadne-data/costs_2019-modifications.csv"
@@ -315,6 +317,7 @@ rule export_ariadne_variables:
         hours=config_provider("clustering","temporal","resolution_sector"),
         costs=config_provider("costs"),
         energy_totals_year=config_provider("energy", "energy_totals_year"),
+        co2_price_add_on_fossils = config_provider("co2_price_add_on_fossils"),
     input:
         template=resources("template_ariadne_database.xlsx"),
         industry_demands=expand(

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -3003,11 +3003,17 @@ def get_investments(n_pre, n, costs, region, dg_cost_factor=1.0, length_factor=1
     # var["Investment|Industry"] = \  
     return var
 
-def get_policy(n):
+def get_policy(n, investment_year):
     var = pd.Series()
-
+    
+    # add carbon component to fossil fuels if specified
+    if investment_year in snakemake.params.co2_price_add_on_fossils.keys():
+        co2_price_add_on  = snakemake.params.co2_price_add_on_fossils[investment_year]
+    else:
+        co2_price_add_on = 0.0
+        
     var["Price|Carbon"] = \
-        -n.global_constraints.loc["CO2Limit", "mu"] - n.global_constraints.loc["co2_limit-DE", "mu"]
+        -n.global_constraints.loc["CO2Limit", "mu"] - n.global_constraints.loc["co2_limit-DE", "mu"] + co2_price_add_on
 
     return var
 
@@ -3052,7 +3058,7 @@ def get_ariadne_var(n, industry_demand, energy_totals, costs, region, year):
             dg_cost_factor=snakemake.params.dg_cost_factor,
             length_factor=snakemake.params.length_factor
         ),
-        get_policy(n),
+        get_policy(n, year),
     ])
 
     return var

--- a/workflow/scripts/modify_cost_data.py
+++ b/workflow/scripts/modify_cost_data.py
@@ -3,6 +3,33 @@ import pandas as pd
 import re
 import os
 import logging
+import numpy as np
+
+def carbon_component_fossils(costs, co2_price):
+    """
+    Add carbon component to fossil fuel costs
+    """
+
+    carriers= ["gas", "oil", "lignite", "coal"]
+    # specific emissions in tons CO2/MWh according to n.links[n.links.carrier =="your_carrier].efficiency2.unique().item()
+    specific_emisisons = {
+        "oil" : 0.2571,
+        "gas" : 0.198, # OCGT
+        "coal" : 0.3361,
+        "lignite" : 0.4069,
+    }
+    
+    for c in carriers:
+        carbon_add_on = specific_emisisons[c] * co2_price
+        costs.at[(c, "fuel"), "value"] += carbon_add_on
+        add_str = f" (added carbon component of {round(carbon_add_on,4)} €/MWh according to co2 price of {co2_price} €/t co2 and carbon intensity of {specific_emisisons[c]} t co2/MWh)"
+        if pd.isna(costs.at[(c, "fuel"), "further description"]):
+            costs.at[(c, "fuel"), "further description"] = add_str
+        else:
+            costs.at[(c, "fuel"), "further description"] = str(costs.at[(c, "fuel"), "further description"]) + add_str
+
+    return costs
+
 
 if __name__ == "__main__":
     if "snakemake" not in globals():
@@ -13,10 +40,10 @@ if __name__ == "__main__":
         from _helpers import mock_snakemake
         snakemake = mock_snakemake(
             "modify_cost_data",
-            planning_horizons="2030",
+            planning_horizons="2020",
             file_path="../data/costs/",
-            file_name="costs_2030.csv",
-            cost_horizon="pessimist",
+            file_name="costs_2020.csv",
+            cost_horizon="mean",
             run="KN2045_Bal_v4"
             )
     logger = logging.getLogger(__name__)
@@ -65,9 +92,17 @@ if __name__ == "__main__":
     else:
         logger.warning(f"NEP year {snakemake.params.NEP} is not in modifications file. Falling back to NEP2021.")
         modifications = modifications.query("source != 'NEP2023'")
-
+        
     costs.loc[modifications.index] = modifications
-
     print(costs.loc[modifications.index])
 
+    # add carbon component to fossil fuel costs
+    investment_year = int(snakemake.wildcards.planning_horizons[-4:])
+    if investment_year in snakemake.params.co2_price_add_on_fossils.keys():
+        co2_price  = snakemake.params.co2_price_add_on_fossils[investment_year]
+        logger.warning(f"Adding carbon component according to a co2 price of {co2_price} €/t to fossil fuel costs.")
+        costs = carbon_component_fossils(costs, co2_price)
+
+    print(costs.at[("gas", "fuel"), "value"])
+    print(costs.at[("gas", "fuel"), "further description"])
     costs.to_csv(snakemake.output[0])

--- a/workflow/scripts/modify_cost_data.py
+++ b/workflow/scripts/modify_cost_data.py
@@ -103,6 +103,4 @@ if __name__ == "__main__":
         logger.warning(f"Adding carbon component according to a co2 price of {co2_price} €/t to fossil fuel costs.")
         costs = carbon_component_fossils(costs, co2_price)
 
-    print(costs.at[("gas", "fuel"), "value"])
-    print(costs.at[("gas", "fuel"), "further description"])
     costs.to_csv(snakemake.output[0])


### PR DESCRIPTION
Adding carbon price in 2020 and 2025 for fossil generators 
- reason: electricity generation from lignite too high and from gas too low in 2020

prices so far:
<img src="https://github.com/PyPSA/pypsa-ariadne/assets/30044662/8e4bef8a-f5b0-49f5-8f49-39aef39bf63a" width="50%" />

<img src="https://github.com/PyPSA/pypsa-ariadne/assets/30044662/22ee1b93-b1cb-4939-86a7-024a6e566fc0" width="50%" />

add ons for specific emissions:
<img src="https://github.com/PyPSA/pypsa-ariadne/assets/30044662/b044a8f0-3406-45e7-82bd-6400b0c07f8d" width="50%" />

prices now:
<img src="https://github.com/PyPSA/pypsa-ariadne/assets/30044662/3aff5b25-1dc4-4f60-b208-3b4b10f1881e" width="50%" />

difference in electricity generation:
before: 
<img src="https://github.com/PyPSA/pypsa-ariadne/assets/30044662/4487366b-259a-4705-8132-a69dceb9a23d" width="50%" />

after:
<img src="https://github.com/PyPSA/pypsa-ariadne/assets/30044662/5656fcf6-08a9-4800-b644-ccf85606cb8d" width="50%" />

ariadne plots:
before:
<img src="https://github.com/PyPSA/pypsa-ariadne/assets/30044662/b5c1694b-683b-45c3-a02b-c87efeef2c3b" width="50%" />

after:
<img src="https://github.com/PyPSA/pypsa-ariadne/assets/30044662/1012cc41-64aa-4e05-ae27-a974c881e570" width="50%" />

