### PR TITLE
Add max capacity limits for renewable energies in Germany

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -117,15 +117,15 @@ limits_capacity_max:
   Generator:
     onwind:
       DE:
-        2020: 48
-        2025: 61
+        2020: 0
+        2025: 69
     offwind:
       DE:
-        2020: 7.77
+        2020: 0
         2025: 8
     solar:
       DE:
-        2020: 59
+        2020: 0
         2025: 101 # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW, assuming at least 1/3 of difference reached in 2025
 
 limits_capacity_min:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -196,7 +196,7 @@ costs:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
-  # solar_thermal: false
+  solar_thermal: false
   district_heating:
     potential: 0.4
     progress:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20240527wasteCHP
+  prefix: max_RE_cap
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -113,20 +113,31 @@ co2_budget:
   2045: 0.050
   2050: 0.000 # climate-neutral by 2050
 
+limits_capacity_max:
+  Generator:
+    onwind:
+      DE:
+        2020: 48
+        2025: 61
+    offwind:
+      DE:
+        2020: 7.77
+        2025: 8
+    solar:
+      DE:
+        2020: 59
+        2025: 101 # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW, assuming at least 1/3 of difference reached in 2025
+
 limits_capacity_min:
     Generator:
       onwind:
         DE:
-          2020: 48
-          2025: 61
           2030: 115 # Wind-an-Land Law
           2035: 157 # Wind-an-Land Law
           2040: 160 # Wind-an-Land Law
           2045: 160
       offwind:
         DE:
-          2020: 7.77
-          2025: 8
           2030: 30 # Wind-auf-See Law
           2035: 40 # 40 Wind-auf-See Law
           # assuming at least 1/3 of difference reached in 2040
@@ -134,10 +145,6 @@ limits_capacity_min:
           2045: 70 #70 Wind-auf-See Law
       solar:
         DE:
-          2020: 59
-          # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW, 
-          # assuming at least 1/3 of difference reached in 2025
-          2025: 101 
           2030: 215 # PV strategy
           2035: 309
           2040: 400 # PV strategy

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -196,7 +196,7 @@ costs:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
-  solar_thermal: false
+  # solar_thermal: false
   district_heating:
     potential: 0.4
     progress:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: max_RE_cap
+  prefix: 20240603max_RE_cap
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -117,16 +117,16 @@ limits_capacity_max:
   Generator:
     onwind:
       DE:
-        2020: 0
+        2020: 54
         2025: 69
     offwind:
       DE:
-        2020: 0
+        2020: 8
         2025: 8
     solar:
       DE:
-        2020: 0
-        2025: 101 # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW, assuming at least 1/3 of difference reached in 2025
+        2020: 54
+        2025: 110 # EEG2023; assumes for 2026: 128 GW, assuming a fair share reached by end of 2025
 
 limits_capacity_min:
     Generator:
@@ -145,6 +145,9 @@ limits_capacity_min:
           2045: 70 #70 Wind-auf-See Law
       solar:
         DE:
+          # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW, 
+          # assuming at least 1/3 of difference reached in 2025
+          2025: 101 
           2030: 215 # PV strategy
           2035: 309
           2040: 400 # PV strategy

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -39,26 +39,18 @@ CurrentPolicies:
     Generator:
       onwind:
         DE:
-          2020: 48
-          2025: 61
           2030: 86.5   # 75 % Wind-an-Land Law
           2035: 86.5
           2040: 86.5
           2045: 86.5
       offwind:
         DE:
-          2020: 7.77
-          2025: 8
           2030: 22.5   # 75 % Wind-auf-See Law
           2035: 22.5
           2040: 22.5
           2045: 22.5
       solar:
         DE:
-          2020: 59
-            # EEG2023; Ziel for 2024: 88 GW and for 2026: 128 GW, 
-            # assuming at least 1/3 of difference reached in 2025
-          2025: 101
           2030: 161.25   # 75 % PV strategy
           2035: 161.25
           2040: 161.25

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -341,32 +341,7 @@ KN2045plus_EasyRide:
         2035: 0
         2040: 0
         2045: 0
-  limits_capacity_min:
-    Generator:
-      onwind:
-        DE:
-          2020: 48
-          2025: 61
-          2030: 115 # Wind-an-Land Law
-          2035: 115 # not forcing more EE
-          2040: 115
-          2045: 115
-      offwind:
-        DE:
-          2020: 7.77
-          2025: 8
-          2030: 30 # Wind-auf-See Law
-          2035: 30 # not forcing more EE
-          2040: 30
-          2045: 30
-      solar:
-        DE:
-          2020: 59
-          2025: 101 
-          2030: 215 # PV strategy
-          2035: 215 # not forcing more EE
-          2040: 215
-          2045: 215
+
 
 KN2045plus_LowDemand:
 # Im Vergleich zu Easy Ride eher knappe EE Erzeugung 
@@ -423,32 +398,7 @@ KN2045plus_LowDemand:
         2035: 0
         2040: 0
         2045: 0
-  limits_capacity_min:
-    Generator:
-      onwind:
-        DE:
-          2020: 48
-          2025: 61
-          2030: 115 # Wind-an-Land Law
-          2035: 115 # not forcing more EE
-          2040: 115
-          2045: 115
-      offwind:
-        DE:
-          2020: 7.77
-          2025: 8
-          2030: 30 # Wind-auf-See Law
-          2035: 30 # not forcing more EE
-          2040: 30
-          2045: 30
-      solar:
-        DE:
-          2020: 59
-          2025: 101 
-          2030: 215 # PV strategy
-          2035: 215 # not forcing more EE
-          2040: 215
-          2045: 215
+
 
 KN2045minus_WorstCase:
 # Nachfrage nach Endenergie ist höher als in den Szenarien 1-3

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -51,6 +51,7 @@ CurrentPolicies:
           2045: 22.5
       solar:
         DE:
+          2025: 101 
           2030: 161.25   # 75 % PV strategy
           2035: 161.25
           2040: 161.25
@@ -520,23 +521,18 @@ KN2045minus_WorstCase:
     Generator:
       onwind:
         DE:
-          2020: 48
-          2025: 61
           2030: 115 # Wind-an-Land Law
           2035: 115 # not forcing more EE
           2040: 115
           2045: 115
       offwind:
         DE:
-          2020: 7.77
-          2025: 8
           2030: 30 # Wind-auf-See Law
           2035: 30 # not forcing more EE
           2040: 30
           2045: 30
       solar:
         DE:
-          2020: 59
           2025: 101 
           2030: 215 # PV strategy
           2035: 215 # not forcing more EE
@@ -610,23 +606,18 @@ KN2045minus_SupplyFocus:
     Generator:
       onwind:
         DE:
-          2020: 48
-          2025: 61
           2030: 115 # Wind-an-Land Law
           2035: 115 # not forcing more EE
           2040: 115
           2045: 115
       offwind:
         DE:
-          2020: 7.77
-          2025: 8
           2030: 30 # Wind-auf-See Law
           2035: 30 # not forcing more EE
           2040: 30
           2045: 30
       solar:
         DE:
-          2020: 59
           2025: 101 
           2030: 215 # PV strategy
           2035: 215 # not forcing more EE

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -24,14 +24,13 @@ def add_min_limits(n, investment_year, config):
 
                 logger.info(f"Adding constraint on {c.name} {carrier} capacity in {ct} to be greater than {limit} MW")
 
-                existing_index = c.df.index[(c.df.index.str[:2] == ct) & 
-                                            (c.df.carrier.str[:len(carrier)] == carrier) &
-                                            ~c.df.carrier.str.contains("thermal") & # exclude solar thermal
-                                            ~c.df.p_nom_extendable]
-                extendable_index = c.df.index[(c.df.index.str[:2] == ct) &
-                                              (c.df.carrier.str[:len(carrier)] == carrier) &
-                                              ~c.df.carrier.str.contains("thermal") & # exclude solar thermal
-                                              c.df.p_nom_extendable]
+                valid_components = (
+                    (c.df.index.str[:2] == ct) &
+                    (c.df.carrier.str[:len(carrier)] == carrier) &
+                    ~c.df.carrier.str.contains("thermal")) # exclude solar thermal
+                
+                existing_index = c.df.index[valid_components & ~c.df.p_nom_extendable]
+                extendable_index = c.df.index[valid_components & c.df.p_nom_extendable]
 
                 existing_capacity = c.df.loc[existing_index, "p_nom"].sum()
 
@@ -67,14 +66,13 @@ def add_max_limits(n, investment_year, config):
                     continue
                 limit = 1e3*config["limits_capacity_max"][c.name][carrier][ct][investment_year]
 
-                existing_index = c.df.index[(c.df.index.str[:2] == ct) &
-                                            (c.df.carrier.str[:len(carrier)] == carrier) &
-                                            ~c.df.carrier.str.contains("thermal") & # exclude solar thermal
-                                            ~c.df.p_nom_extendable]
-                extendable_index = c.df.index[(c.df.index.str[:2] == ct) &
-                                              (c.df.carrier.str[:len(carrier)] == carrier) &
-                                              ~c.df.carrier.str.contains("thermal") & # exclude solar thermal
-                                              c.df.p_nom_extendable]
+                valid_components = (
+                    (c.df.index.str[:2] == ct) &
+                    (c.df.carrier.str[:len(carrier)] == carrier) &
+                    ~c.df.carrier.str.contains("thermal")) # exclude solar thermal
+                
+                existing_index = c.df.index[valid_components & ~c.df.p_nom_extendable]
+                extendable_index = c.df.index[valid_components & c.df.p_nom_extendable]
 
                 existing_capacity = c.df.loc[existing_index, "p_nom"].sum()
 

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -24,15 +24,13 @@ def add_min_limits(n, investment_year, config):
 
                 logger.info(f"Adding constraint on {c.name} {carrier} capacity in {ct} to be greater than {limit} MW")
 
-                forbidden = ["solar thermal"]
-
                 existing_index = c.df.index[(c.df.index.str[:2] == ct) & 
                                             (c.df.carrier.str[:len(carrier)] == carrier) &
-                                            ~c.df.carrier.isin(forbidden) & 
+                                            ~c.df.carrier.str.contains("thermal") & # exclude solar thermal
                                             ~c.df.p_nom_extendable]
                 extendable_index = c.df.index[(c.df.index.str[:2] == ct) &
                                               (c.df.carrier.str[:len(carrier)] == carrier) &
-                                              ~c.df.carrier.isin(forbidden) &
+                                              ~c.df.carrier.str.contains("thermal") & # exclude solar thermal
                                               c.df.p_nom_extendable]
 
                 existing_capacity = c.df.loc[existing_index, "p_nom"].sum()
@@ -69,16 +67,13 @@ def add_max_limits(n, investment_year, config):
                     continue
                 limit = 1e3*config["limits_capacity_max"][c.name][carrier][ct][investment_year]
 
-
-                forbidden = ["solar thermal"]
-
                 existing_index = c.df.index[(c.df.index.str[:2] == ct) &
                                             (c.df.carrier.str[:len(carrier)] == carrier) &
-                                            ~c.df.carrier.isin(forbidden) &
+                                            ~c.df.carrier.str.contains("thermal") & # exclude solar thermal
                                             ~c.df.p_nom_extendable]
                 extendable_index = c.df.index[(c.df.index.str[:2] == ct) &
                                               (c.df.carrier.str[:len(carrier)] == carrier) &
-                                              ~c.df.carrier.isin(forbidden) &
+                                              ~c.df.carrier.str.contains("thermal") & # exclude solar thermal
                                               c.df.p_nom_extendable]
 
                 existing_capacity = c.df.loc[existing_index, "p_nom"].sum()


### PR DESCRIPTION
Since our results showed too much renewable energies in 2020 and 2025, a maximum constraint is introduced.
`config["limits_capacity_max"]` follows the same logic as `config["limits_capacity_min"].
Be aware that defining both upper and lower limits for renewables is possible but might lead to numerical issues.