### PR TITLE
uba trajectories for national climate targets

### DIFF
--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -30,6 +30,9 @@ CurrentPolicies:
     2045: 0.450
     2050: 0.450
 
+  co2_budget_uba:
+    enable: true
+
   costs:
     horizon: "mean"
 
@@ -122,6 +125,9 @@ KN2045_Bal_v4:
   iiasa_database:
     reference_scenario: 8Gt_Bal_v3
 
+  co2_budget_uba:
+    enable: true
+
   costs:
     horizon: "mean"
 
@@ -178,6 +184,9 @@ KN2045_Elec_v4:
   iiasa_database:
     reference_scenario: 8Gt_Elec_v3
 
+  co2_budget_uba:
+    enable: true
+
   costs:
     horizon: "mean"
 
@@ -232,6 +241,9 @@ KN2045_H2_v4:
 
   iiasa_database:
     reference_scenario: 8Gt_H2_v3
+
+  co2_budget_uba:
+    enable: true
 
   costs:
     horizon: "mean"
@@ -290,6 +302,9 @@ KN2045plus_EasyRide:
 # Verlagerung der energieintensiven Grundstoffindustrie
   iiasa_database:
     reference_scenario: 8Gt_EasyRide_v3 # TODO: wait for database
+
+  co2_budget_uba:
+    enable: true
 
   costs:
     horizon: "optimist"
@@ -370,6 +385,9 @@ KN2045plus_LowDemand:
 # innerhalb Deutschlands und knappe Importe EE möglich
   iiasa_database:
     reference_scenario: 8Gt_LowDemand_v3 # TODO: wait for database
+
+  co2_budget_uba:
+    enable: true    
 
   costs:
     horizon: "optimist"
@@ -463,6 +481,9 @@ KN2045minus_WorstCase:
     2045: 0.450
     2050: 0.450
 
+  co2_budget_uba:
+    enable: true
+
   costs:
     horizon: "pessimist"
 
@@ -554,6 +575,10 @@ KN2045minus_SupplyFocus:
     2040: 0.450
     2045: 0.450
     2050: 0.450
+
+  co2_budget_uba:
+    enable: true
+
   # boundary condition of maximum volumes
   limits_volume_max: # following the Bal scenario
     # constrain electricity import in TWh


### PR DESCRIPTION
Partially addressing issue https://github.com/PyPSA/pypsa-ariadne/issues/81
Sector goals are not easily applicable, since due to sector coupling PyPSA-Eur can't distinguish between e.g. oil/hydrogen for different applications.
New config `co2_budget_uba` was added. In `build_scenarios` the [trajectory from 2024 ](https://www.umweltbundesamt.de/themen/klima-energie/klimaschutz-energiepolitik-in-deutschland/szenarien-fuer-die-klimaschutz-energiepolitik/integrierte-energie-treibhausgasprojektionen) is added minus the expected non CO2 emissions from the iiasa database.
The relative reduction is then written into `config["co2_budget_uba"]["targets"]` but only come into effect if `config["co2_budget_uba"]["enable"] == True`.

Reduction compared to 1990 emissions
| Year          | uba   | KSG |
|--------------------------|-----------|-----------|
| 2020 | 0.61       | 0.728 |
| 2025 | 0.557     | 0.573 |
| 2030 | 0.391     | 0.401 |
| 2035 | 0.268     | 0.265 |
| 2040 | 0.177     | 0.135 |
| 2045 | 0.151     | -0.011|

**Waiting for decision whether to implement a electricity sector target.**