### PR TITLE
Shipping MeOH

### DIFF
--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -367,12 +367,8 @@ def add_h2_derivate_limit(n, snapshots, investment_year, config):
 
         logger.info(f"limiting H2 derivate imports in {ct} to {limit/1e6} TWh/a")
 
-        oil_meoh_in = n.links.loc[["EU renewable oil -> DE oil", "EU methanol -> DE methanol"]].index
-        gas_in = n.links[(n.links.bus0.str[:2] != ct) & (n.links.bus1.str[:2] == ct) & (n.links.index.str.contains("pipeline"))].index
-        incoming = oil_meoh_in.union(gas_in)
-        gas_out = n.links[(n.links.bus0.str[:2] == ct) & (n.links.bus1.str[:2] != ct) & (n.links.index.str.contains("pipeline"))].index
-        oil_meoh_out = n.links.loc[["DE renewable oil -> EU oil", "DE methanol -> EU methanol"]].index
-        outgoing = oil_meoh_out.union(gas_out)
+        incoming = n.links.loc[["EU renewable oil -> DE oil", "EU methanol -> DE methanol"]].index
+        outgoing = n.links.loc[["DE renewable oil -> EU oil", "DE methanol -> EU methanol"]].index
 
         incoming_p = (n.model["Link-p"].loc[:, incoming]*n.snapshot_weightings.generators).sum()
         outgoing_p = (n.model["Link-p"].loc[:, outgoing]*n.snapshot_weightings.generators).sum()

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -367,8 +367,12 @@ def add_h2_derivate_limit(n, snapshots, investment_year, config):
 
         logger.info(f"limiting H2 derivate imports in {ct} to {limit/1e6} TWh/a")
 
-        incoming = n.links.index[n.links.index.str.contains("EU renewable oil -> DE oil")]
-        outgoing = n.links.index[n.links.index.str.contains("DE renewable oil -> EU oil")]
+        oil_meoh_in = n.links.loc[["EU renewable oil -> DE oil", "EU methanol -> DE methanol"]].index
+        gas_in = n.links[(n.links.bus0.str[:2] != ct) & (n.links.bus1.str[:2] == ct) & (n.links.index.str.contains("pipeline"))].index
+        incoming = oil_meoh_in.union(gas_in)
+        gas_out = n.links[(n.links.bus0.str[:2] == ct) & (n.links.bus1.str[:2] != ct) & (n.links.index.str.contains("pipeline"))].index
+        oil_meoh_out = n.links.loc[["DE renewable oil -> EU oil", "DE methanol -> EU methanol"]].index
+        outgoing = oil_meoh_out.union(gas_out)
 
         incoming_p = (n.model["Link-p"].loc[:, incoming]*n.snapshot_weightings.generators).sum()
         outgoing_p = (n.model["Link-p"].loc[:, outgoing]*n.snapshot_weightings.generators).sum()

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -30,14 +30,21 @@ def get_transport_shares(df, planning_horizons):
         df.loc["REMIND-EU v1.1", "Final Energy|Bunkers|Navigation"] + \
         df.loc["Aladin v1", "Final Energy|Transportation|Domestic Navigation"]
     navigation_liquid = \
-        df.loc["REMIND-EU v1.1", "Final Energy|Bunkers|Navigation|Liquids"] + \
-        df.loc["Aladin v1", "Final Energy|Transportation|Domestic Navigation|Liquids"]
-    
+        df.loc["REMIND-EU v1.1", "Final Energy|Bunkers|Navigation|Liquids|Petroleum"] + \
+        df.loc["Aladin v1", "Final Energy|Transportation|Domestic Navigation|Liquids|Petroleum"]
+
+    navigation_meoh = \
+        df.loc["REMIND-EU v1.1", "Final Energy|Bunkers|Navigation|Liquids|Biomass"] + \
+        df.loc["REMIND-EU v1.1", "Final Energy|Bunkers|Navigation|Liquids|Efuel"] + \
+        df.loc["Aladin v1", "Final Energy|Transportation|Domestic Navigation|Liquids|Biomass"] + \
+        df.loc["Aladin v1", "Final Energy|Transportation|Domestic Navigation|Liquids|Synthetic Fossil"] + \
+        df.loc["Aladin v1", "Final Energy|Transportation|Domestic Navigation|Liquids|Efuel"]
+
     navigation_h2 = df.loc["Aladin v1", "Final Energy|Transportation|Domestic Navigation|Hydrogen"]    
 
     h2_share = navigation_h2 / total_navigation
     liquid_share = navigation_liquid / total_navigation
-    methanol_share = (1 - h2_share - liquid_share).round(6)
+    methanol_share = navigation_meoh / total_navigation
     
     naval_share = pd.concat(
             [liquid_share, h2_share, methanol_share]).set_index(

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -294,6 +294,45 @@ def unravel_oilbus(n):
           e_cyclic=True,
           capital_cost=0.02,
           )
+    
+    # unravel meoh
+    logger.info("Unraveling methanol bus")
+    # add bus
+    n.add(
+        "Bus", 
+        "DE methanol", 
+        location="DE",
+        x=n.buses.loc["DE","x"],
+        y=n.buses.loc["DE","y"],
+        carrier="methanol"
+    )
+    
+    # change links from EU meoh to DE meoh
+    DE_meoh_out = n.links[(n.links.bus0=="EU methanol") & (n.links.index.str[:2]=="DE")].index
+    n.links.loc[DE_meoh_out, "bus0"] = "DE methanol"
+    DE_meoh_in = n.links[(n.links.bus1=="EU methanol") & (n.links.index.str[:2]=="DE")].index
+    n.links.loc[DE_meoh_in, "bus1"] = "DE methanol"
+
+    # add links between methanol buses
+    n.madd(
+        "Link",
+        ["EU methanol -> DE methanol", "DE methanol -> EU methanol"],
+        bus0=["EU methanol", "DE methanol"],
+        bus1=["DE methanol", "EU methanol"],
+        carrier="methanol",
+        p_nom=1e6,
+        p_min_pu=0,
+    )
+
+    # add stores
+    n.add("Store",
+          "DE methanol Store",
+          bus="DE methanol",
+          carrier="methanol",
+          e_nom_extendable=True,
+          e_cyclic=True,
+          capital_cost=0.02,
+          )
 
 
 def transmission_costs_from_modified_cost_data(n, costs, transmission, length_factor=1.0):
@@ -355,10 +394,10 @@ if __name__ == "__main__":
             simpl="",
             clusters=22,
             opts="",
-            ll="v1.2",
-            sector_opts="365H-T-H-B-I-A-solar+p3-linemaxext15",
-            planning_horizons="2040",
-            run="KN2045_H2_v4"
+            ll="vopt",
+            sector_opts="none",
+            planning_horizons="2020",
+            run="KN2045_Bal_v4"
         )
 
     logger.info("Adding Ariadne-specific functionality")


### PR DESCRIPTION
Adding synthetic fuels, biofuels and ft fuels in navigation as meoh demand. However, this seems to be drastic and leads to 100 % meoh shipping in 2045. Not realistic especially considering the current fleet of ships and their lifetime.
```
sector:
    shipping_methanol_share:
      2020: 0.0966
      2025: 0.1187
      2030: 0.1357
      2035: 0.175
      2040: 0.4558
      2045: 1.0
```
In the `unravel_oilbus()` meoh was missing which is needed for industry and shipping. It is following now the same logic as for the oil and added to the boundary condition restricting the import of H2 derivatives (which also missed the import of CH4 on purpose?).