### PR TITLE
Set up config for CI runs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,9 +29,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - {artifact_name: "results (feature branch)", path: "~/pypsa-ariadne/feature/results"}
-          - {artifact_name: "results (base branch)", path: "~/pypsa-ariadne/main/results"}
-          - {artifact_name: "validator-metadata", path: "~/pypsa-ariadne/validator-metadata.yml"}
+          - {artifact_name: "results (feature branch)", path: "~/${{ github.repository }}/feature/results"}
+          - {artifact_name: "results (base branch)", path: "~/${{ github.repository }}/main/results"}
+          - {artifact_name: "validator-metadata", path: "~/${{ github.repository }}/validator-metadata.yml"}
     steps:
     - name: Upload artifacts - ${{ matrix.artifact_name }}
       uses: actions/upload-artifact@v4
@@ -56,8 +56,8 @@ jobs:
           # <scenario>/<plot_name>.png
           plots: >
             "
-            KN2045_Bal_v4/graphs/energy.svg
-            KN2045_Bal_v4/graphs/costs.svg
-            KN2045_Bal_v4/graphs/balances-AC.svg
+            KN2045_Bal_v4/ariadne/primary_energy.png
+            KN2045_Bal_v4/ariadne/secondary_energy.png
+            KN2045_Bal_v4/ariadne/final_energy.png
             "
           repo_private_key: ${{ secrets.REPO_PLOTS_PRIVATE_KEY }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,63 @@
+name: Validator Bot
+
+on:
+  pull_request:
+    branches:
+    - master
+    - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-validation:
+    name: Run validation
+    runs-on: self-hosted
+    steps:
+    - uses: lkstrp/pypsa-validator@main
+      with:
+        step: run-self-hosted-validation
+        env_file: environment.yaml
+        snakemake_config: config/config.yaml
+        pre_command: "-call build_scenarios -f"
+
+  upload-artifacts:
+    name: Upload artifacts
+    needs: run-validation
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        include:
+          - {artifact_name: "results (feature branch)", path: "~/pypsa-ariadne/feature/results"}
+          - {artifact_name: "results (base branch)", path: "~/pypsa-ariadne/main/results"}
+          - {artifact_name: "validator-metadata", path: "~/pypsa-ariadne/validator-metadata.yml"}
+    steps:
+    - name: Upload artifacts - ${{ matrix.artifact_name }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact_name }}
+        path: |
+            ${{ matrix.path }}
+        if-no-files-found: error
+        retention-days: 90
+
+  comment-on-pr:
+    name: Comment on pull request
+    needs: upload-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lkstrp/pypsa-validator@main
+        with:
+          step: create-comment
+          snakemake_config: config/config.yaml
+          # The path starting from prefix in config
+          # For plot results/<prefix>/<scenario>/<plot_name>.png pass
+          # <scenario>/<plot_name>.png
+          plots: >
+            "
+            KN2045_Bal_v4/graphs/energy.svg
+            KN2045_Bal_v4/graphs/costs.svg
+            KN2045_Bal_v4/graphs/balances-AC.svg
+            "
+          repo_private_key: ${{ secrets.REPO_PLOTS_PRIVATE_KEY }}


### PR DESCRIPTION
Just 1 scenario, no solar thermal.

Still this workflow takes ~30 minutes locally due to all the pre-processing. I guess some further simplifications are necessary for the CI runs, e.g. disabling "estimate_renewables" and using a default cutout. Here i would need some input from @fneum 