### PR TITLE
Transport Demand from Aladin Sector Model

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,21 +4,21 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20240613scenariosredefined
+  prefix: transport_aladin
   name:
-  - CurrentPolicies
+  # - CurrentPolicies
   - KN2045_Bal_v4
-  - KN2045_Elec_v4
-  - KN2045_H2_v4
-  - KN2045plus_EasyRide
-  - KN2045plus_LowDemand
-  - KN2045minus_WorstCase
-  - KN2045minus_SupplyFocus
+  # - KN2045_Elec_v4
+  # - KN2045_H2_v4
+  # - KN2045plus_EasyRide
+  # - KN2045plus_LowDemand
+  # - KN2045minus_WorstCase
+  # - KN2045minus_SupplyFocus
   scenarios:
     enable: true
     file: config/scenarios.automated.yaml
   shared_resources: 
-    policy: base #stops recalculating
+    policy: true #stops recalculating
     exclude:
       - existing_heating.csv # specify files which should not be shared between scenarios
       - costs
@@ -223,7 +223,7 @@ costs:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
-  # solar_thermal: false
+  solar_thermal: false
   district_heating:
     potential: 0.4
     progress:
@@ -257,6 +257,30 @@ sector:
     2040: 0.29
     2045: 0.36
     2050: 0.43
+  land_transport_fuel_cell_share:
+    2020: 0.05
+    2025: 0.05
+    2030: 0.05
+    2035: 0.05
+    2040: 0.05
+    2045: 0.05
+    2050: 0.05
+  land_transport_electric_share:
+    2020: 0.05
+    2025: 0.15
+    2030: 0.3
+    2035: 0.45
+    2040: 0.7
+    2045: 0.85
+    2050: 0.95
+  land_transport_ice_share:
+    2020: 0.9
+    2025: 0.8
+    2030: 0.65
+    2035: 0.5
+    2040: 0.25
+    2045: 0.1
+    2050: 0.0
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#industry
 industry:
@@ -316,11 +340,11 @@ solving:
   options:
     assign_all_duals: true
     load_shedding: false
-    skip_iterations: false # settings for post-discretization: false
+    skip_iterations: true # settings for post-discretization: false
     min_iterations: 1 # settings for post-discretization: 1
     max_iterations: 1 # settings for post-discretization: 1
     post_discretization:
-      enable: true
+      enable: false
       line_unit_size: 1700
       line_threshold: 0.3
       link_unit_size:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -129,6 +129,22 @@ rule modify_cost_data:
 if config["enable"]["retrieve"] and config["enable"].get("retrieve_cost_data", True):
     ruleorder: modify_cost_data > retrieve_cost_data
 
+
+rule build_mobility_demand:
+    params:
+        reference_scenario=config_provider("iiasa_database", "reference_scenario"),
+        planning_horizons=config_provider("scenario", "planning_horizons"),
+    input:
+        ariadne=resources("ariadne_database.csv"),
+        clustered_pop_layout=resources("pop_layout_elec_s{simpl}_{clusters}.csv"),
+    output:
+        mobility_demand=resources("mobility_demand_aladin_{planning_horizons}.csv"),
+    resources:
+        mem_mb=1000
+    script:
+        "scripts/build_mobility_demand.py"
+
+
 rule modify_prenetwork:
     params:
         enable_kernnetz=config_provider("wasserstoff_kernnetz", "enable"),

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -138,7 +138,7 @@ rule build_mobility_demand:
         ariadne=resources("ariadne_database.csv"),
         clustered_pop_layout=resources("pop_layout_elec_s{simpl}_{clusters}.csv"),
     output:
-        mobility_demand=resources("mobility_demand_aladin_{planning_horizons}.csv"),
+        mobility_demand=resources("mobility_demand_aladin_{simpl}_{clusters}_{planning_horizons}.csv"),
     resources:
         mem_mb=1000
     script:
@@ -161,11 +161,15 @@ rule modify_prenetwork:
         H2_retrofit_capacity_per_CH4=config_provider("sector", "H2_retrofit_capacity_per_CH4"),
         transmission_costs=config_provider("costs", "transmission"),
         biomass_must_run=config_provider("must_run_biomass"),
+        clustering=config_provider("clustering", "temporal", "resolution_sector"),
     input:
         network=RESULTS
         + "prenetworks-brownfield/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
         wkn=resources("wasserstoff_kernnetz_elec_s{simpl}_{clusters}.csv") if config_provider("wasserstoff_kernnetz", "enable") else [],
         costs=resources("costs_{planning_horizons}.csv"),
+        aladin_demand=resources("mobility_demand_aladin_{simpl}_{clusters}_{planning_horizons}.csv"),
+        transport_demand=resources("transport_demand_s{simpl}_{clusters}.csv"),
+        transport_data=resources("transport_data_s{simpl}_{clusters}.csv"),
     output:
         network=RESULTS
         + "prenetworks-final/elec_s{simpl}_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -168,7 +168,6 @@ rule modify_prenetwork:
         wkn=resources("wasserstoff_kernnetz_elec_s{simpl}_{clusters}.csv") if config_provider("wasserstoff_kernnetz", "enable") else [],
         costs=resources("costs_{planning_horizons}.csv"),
         aladin_demand=resources("mobility_demand_aladin_{simpl}_{clusters}_{planning_horizons}.csv"),
-        transport_demand=resources("transport_demand_s{simpl}_{clusters}.csv"),
         transport_data=resources("transport_data_s{simpl}_{clusters}.csv"),
     output:
         network=RESULTS

--- a/workflow/scripts/build_mobility_demand.py
+++ b/workflow/scripts/build_mobility_demand.py
@@ -1,0 +1,67 @@
+import logging
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+def get_aladin_data():
+    """
+    Retrieve the German mobility demand from the Aladin model.
+    Sum over the subsectors Bus, LDV, Rail, and Truck for the fuels electricity, hydrogen, and synthetic fuels.
+    """
+    # get aladin data
+    db = pd.read_csv(
+        snakemake.input.ariadne,
+        index_col=["model", "scenario", "region", "variable", "unit"]
+    ).loc[
+        "Aladin v1",
+        snakemake.params.reference_scenario,
+        "Deutschland",
+        :,
+        "PJ/yr"]
+    year = snakemake.wildcards.planning_horizons
+
+    subsectors = ["Bus", "LDV", "Rail", "Truck"]
+    fuels = ["Electricity", "Hydrogen", "Liquids"]
+
+    transport_demand = pd.Series(0, index=fuels)
+
+    for fuel in fuels:
+        for subsector in subsectors:
+            key = f"Final Energy|Transportation|{subsector}|{fuel}"
+            transport_demand.loc[fuel] += db.loc[key, year]
+
+    return transport_demand
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        import os
+        import sys
+
+        path = "../submodules/pypsa-eur/scripts"
+        sys.path.insert(0, os.path.abspath(path))
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake(
+            "build_mobility_demand",
+            clusters=22,
+            opts="",
+            ll="vopt",
+            sector_opts="none",
+            planning_horizons="2030",
+            run="KN2045_Bal_v4"
+        )
+
+    logger.info("Retrieving German mobility demand from Aladin model.")
+    # get aladin data
+    aladin = get_aladin_data()   
+
+    # get German mobility weighting
+    pop_layout = pd.read_csv(snakemake.input.clustered_pop_layout, index_col=0)
+    # only get German data
+    pop_layout = pop_layout[pop_layout.ct == "DE"].fraction
+
+    mobility_demand = pd.DataFrame(pop_layout.values[:, None] * aladin.values, index=pop_layout.index, columns=aladin.index)
+
+    mobility_demand.div(3.6e-6) # convert PJ to MWh
+
+    mobility_demand.to_csv(snakemake.output.mobility_demand)

--- a/workflow/scripts/build_mobility_demand.py
+++ b/workflow/scripts/build_mobility_demand.py
@@ -30,7 +30,7 @@ def get_aladin_data():
             key = f"Final Energy|Transportation|{subsector}|{fuel}"
             transport_demand.loc[fuel] += db.loc[key, year].iloc[0]
     
-    transport_demand.div(3.6e-6) # convert PJ to MWh
+    transport_demand = transport_demand.div(3.6e-6) # convert PJ to MWh
     transport_demand["number_of_cars"] = db.loc["Stock|Transportation|LDV|BEV", year].iloc[0]
 
     return transport_demand
@@ -51,7 +51,7 @@ if __name__ == "__main__":
             opts="",
             ll="vopt",
             sector_opts="none",
-            planning_horizons="2030",
+            planning_horizons="2020",
             run="KN2045_Bal_v4"
         )
 

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -18,19 +18,7 @@ def get_transport_growth(df, planning_horizons):
     aviation = df.loc[aviation_model,"Final Energy|Bunkers|Aviation", "PJ/yr"]
     aviation_growth_factor = aviation / aviation[2020]
 
-    # Transport growth factor - using REMIND until Aladin v1 uploads variables
-    transport_model = "REMIND-EU v1.1"
-    freight = df.loc[transport_model, "Energy Service|Transportation|Freight|Road", "bn tkm/yr"]
-    person = df.loc[transport_model, "Energy Service|Transportation|Passenger|Road", "bn pkm/yr"]
-    freight_PJ = df.loc[transport_model, "Final Energy|Transportation|Truck", "PJ/yr"]
-    person_PJ = df.loc[transport_model, "Final Energy|Transportation|LDV", "PJ/yr"]
-    
-    transport_growth_factor = pd.Series()
-    for year in planning_horizons:
-        share = (person_PJ[year] / (person_PJ[year] + freight_PJ[year]))
-        transport_growth_factor.loc[year] = share * (person[year] / person[2020]) + (1 - share) * (freight[year] / freight[2020])
-
-    return aviation_growth_factor[planning_horizons], transport_growth_factor
+    return aviation_growth_factor[planning_horizons]
 
 
 def get_primary_steel_share(df, planning_horizons):
@@ -130,15 +118,13 @@ def write_to_scenario_yaml(
         
         planning_horizons = [2020, 2025, 2030, 2035, 2040, 2045] # for 2050 we still need data
         
-        aviation_demand_factor, land_transport_demand_factor = get_transport_growth(df.loc[:, fallback_reference_scenario, :], planning_horizons)
+        aviation_demand_factor = get_transport_growth(df.loc[:, fallback_reference_scenario, :], planning_horizons)
 
         config[scenario]["sector"] = {}
         
-        config[scenario]["sector"]["land_transport_demand_factor"] = {}
         config[scenario]["sector"]["aviation_demand_factor"] = {}
         for year in planning_horizons:
             config[scenario]["sector"]["aviation_demand_factor"][year] = round(aviation_demand_factor.loc[year].item(), 4)
-            config[scenario]["sector"]["land_transport_demand_factor"][year] = round(land_transport_demand_factor.loc[year].item(), 4)
 
         st_primary_fraction = get_primary_steel_share(df.loc[:, reference_scenario, :], planning_horizons)
         

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -352,9 +352,16 @@ def aladin_mobility_demand(n):
     # normalize transport by the sum of each column
     rel_demand = transport.div(transport.sum(axis=0), axis=1)
     # aggregate rel_demand to n timesteps
-    aggregation_map = pd.Series(index=rel_demand.index).astype("datetime64[ns]")
-    for i in range(0, 8760, int(snakemake.params.clustering[:-1])):
-        aggregation_map.iloc[i:i+int(snakemake.params.clustering[:-1])] = rel_demand.index[i]
+    # aggregation_map = pd.Series(index=rel_demand.index).astype("datetime64[ns]")
+    # for i in range(0, 8760, int(snakemake.params.clustering[:-1])):
+    #     aggregation_map.iloc[i:i+int(snakemake.params.clustering[:-1])] = rel_demand.index[i]
+    aggregation_map = (
+            pd.Series(
+                n.snapshot_weightings.index.get_indexer(n.snapshots), index=n.snapshots
+            )
+            .astype(int)
+            .map(lambda i: n.snapshot_weightings.index[i])
+        )
 
     agg_rel = rel_demand.groupby(aggregation_map).sum()
 
@@ -415,7 +422,7 @@ if __name__ == "__main__":
             opts="",
             ll="vopt",
             sector_opts="none",
-            planning_horizons="2030",
+            planning_horizons="2020",
             run="KN2045_Bal_v4"
         )
 


### PR DESCRIPTION
Adressing https://github.com/PyPSA/pypsa-ariadne/issues/102

This PR now takes the road and rail transport demand for hydrogen, electricity and liquids from the Aladin model that also exports to the ariadne databse.

`rule: build_mobility_demand`
The rule reads the demand for electricity, hydrogen and liquids from buses, LDV, rail and trucks. The number of electric vehicles is also retrieved since it determines the V2G and BEV charger capacities.

`rule: modify_prenetwork`
aladin_mobility_demand
This function gets the loads for `[land transport oil, land transport fuel cell, land transport EV]` and overwrites the loads with the values from the Aladin model. Note that the demand is time dependent and therefore, the relative transport demand is built from the `n.loads_t.p_set` dataframe.
 
## Comparison with Remind
![image](https://github.com/PyPSA/pypsa-ariadne/assets/153275395/31d3b869-e308-480c-8ac7-983f00c3ea91)
![image](https://github.com/PyPSA/pypsa-ariadne/assets/153275395/a8b9c492-05c1-46eb-bdcf-20f5d9cdb307)
