### PR TITLE
Industry Steam from Biomass/Hydrogen/Electricity

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -346,10 +346,6 @@ industry:
     2050: 0.20
   waste_to_energy: true
   waste_to_energy_cc: true
-  steam_biomass_fraction: 0.4
-  steam_hydrogen_fraction: 0.3
-  steam_electricity_fraction: 0.3
-
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#solving
 solving:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20240708morevariables
+  prefix: industry_steam_fractions
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -23,6 +23,8 @@ run:
       - existing_heating.csv # specify files which should not be shared between scenarios
       - costs
       - retrieve_cost # This is necessary to save retrieve_cost_data_{year}.log in the correct folder
+      - industry_sector_ratios
+      - build_industry_sector_ratios # This is necessary to save build_industry_sector_ratios_data.log in the correct folder
   disable_progressbar: true
   debug_co2_limit: false
   debug_h2deriv_limit: false
@@ -344,6 +346,9 @@ industry:
     2050: 0.20
   waste_to_energy: true
   waste_to_energy_cc: true
+  steam_biomass_fraction: 0.4
+  steam_hydrogen_fraction: 0.3
+  steam_electricity_fraction: 0.3
 
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#solving

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -37,6 +37,24 @@ def get_primary_steel_share(df, planning_horizons):
     
     return primary_steel_share.set_index(pd.Index(["Primary_Steel_Share"]))
 
+def get_DRI_share(df, planning_horizons):
+    # Get share of DRI steel production
+    model = "FORECAST v1.0"
+    total_steel = df.loc[model, "Production|Steel|Primary"]
+    # Assuming that only hydrogen DRI steel is sustainable and DRI using natural gas is phased out
+    DRI_steel = df.loc[model, "Production|Steel|Primary|Direct Reduction Hydrogen"]
+
+    DRI_steel_share = DRI_steel / total_steel
+
+    if model == "FORECAST v1.0" and planning_horizons[0] == 2020:
+        logger.warning("FORECAST v1.0 does not have data for 2020. Using 2021 data for DRI fraction instead.")
+        DRI_steel_share[2020] = DRI_steel_share[2021] / total_steel[2021]
+    
+    DRI_steel_share = DRI_steel_share[planning_horizons]
+
+    return DRI_steel_share.set_index(pd.Index(["DRI_Steel_Share"]))
+
+
 def get_co2_budget(df, source):
     # relative to the DE emissions in 1990 *including bunkers*; also
     # account for non-CO2 GHG and allow extra room for international
@@ -128,10 +146,14 @@ def write_to_scenario_yaml(
 
         st_primary_fraction = get_primary_steel_share(df.loc[:, reference_scenario, :], planning_horizons)
         
+        dri_fraction = get_DRI_share(df.loc[:, reference_scenario, :], planning_horizons)
+
         config[scenario]["industry"] = {}
         config[scenario]["industry"]["St_primary_fraction"] = {}
+        config[scenario]["industry"]["DRI_fraction"] = {}
         for year in st_primary_fraction.columns:
             config[scenario]["industry"]["St_primary_fraction"][year] = round(st_primary_fraction.loc["Primary_Steel_Share", year].item(), 4)
+            config[scenario]["industry"]["DRI_fraction"][year] = round(dri_fraction.loc["DRI_Steel_Share", year].item(), 4)
         config[scenario]["co2_budget_national"] = {}
         for year, target in co2_budget_fractions.items():
             config[scenario]["co2_budget_national"][year] = {}

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -55,6 +55,22 @@ def get_DRI_share(df, planning_horizons):
     return DRI_steel_share.set_index(pd.Index(["DRI_Steel_Share"]))
 
 
+def get_steam_share(df):
+    # Get share of steam production from FORECAST v1.0
+    model = "FORECAST v1.0"
+    
+    biomass = df.loc[model, "Final Energy|Industry excl Non-Energy Use|Solids|Biomass"][2045]
+    hydrogen = df.loc[model, "Final Energy|Industry excl Non-Energy Use|Hydrogen"][2045]
+    electricity = df.loc[model, "Final Energy|Industry excl Non-Energy Use|Electricity"][2045]
+    total = biomass + hydrogen + electricity
+
+    biomass_fraction = biomass / total
+    hydrogen_fraction = hydrogen / total
+    electricity_fraction = electricity / total
+
+    return biomass_fraction.iloc[0], hydrogen_fraction.iloc[0], electricity_fraction.iloc[0]
+
+
 def get_co2_budget(df, source):
     # relative to the DE emissions in 1990 *including bunkers*; also
     # account for non-CO2 GHG and allow extra room for international
@@ -154,6 +170,16 @@ def write_to_scenario_yaml(
         for year in st_primary_fraction.columns:
             config[scenario]["industry"]["St_primary_fraction"][year] = round(st_primary_fraction.loc["Primary_Steel_Share", year].item(), 4)
             config[scenario]["industry"]["DRI_fraction"][year] = round(dri_fraction.loc["DRI_Steel_Share", year].item(), 4)
+
+        biomass_share, hydrogen_share, electricity_share = get_steam_share(df.loc[:, reference_scenario, :])
+
+        config[scenario]["industry"]["steam_biomass_fraction"] = {}
+        config[scenario]["industry"]["steam_hydrogen_fraction"] = {}
+        config[scenario]["industry"]["steam_electricity_fraction"] = {}
+        config[scenario]["industry"]["steam_biomass_fraction"] = float(round(biomass_share, 4))
+        config[scenario]["industry"]["steam_hydrogen_fraction"] = float(round(hydrogen_share, 4))
+        config[scenario]["industry"]["steam_electricity_fraction"] = float(round(electricity_share, 4))
+
         config[scenario]["co2_budget_national"] = {}
         for year, target in co2_budget_fractions.items():
             config[scenario]["co2_budget_national"][year] = {}


### PR DESCRIPTION
Closes https://github.com/PyPSA/pypsa-ariadne/issues/121 but is depending on https://github.com/PyPSA/pypsa-eur/pull/1143 which includes detailed information on the pypsa-eur changes.

In `build_scenarios`, the DRI share from FORECAST is taken to provide information on the `config[industry][DRI_fraction]`. With that, the demand for coal in 2045 disappears.
Furthermore, steam fraction are built from the variables `Final Energy|Industry excl Non-Energy Use|Solids|Biomass`, `Final Energy|Industry excl Non-Energy Use|Hydrogen` and `Final Energy|Industry excl Non-Energy Use|Electricity`.
This gives us variation between the industry demand across scenarios.