### PR TITLE
Cutout 2019

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -99,14 +99,19 @@ atlite:
       dx: 0.3
       dy: 0.3
       time: ['2019', '2019']
+
+    
 renewable:
   onwind:
     cutout: europe-2019-sarah3-era5-compressed
   offwind-ac:
+    capacity_per_sqkm: 6
     cutout: europe-2019-sarah3-era5-compressed
   offwind-dc:
+    capacity_per_sqkm: 6
     cutout: europe-2019-sarah3-era5-compressed
   offwind-float:
+    capacity_per_sqkm: 6
     cutout: europe-2019-sarah3-era5-compressed
   solar:
     cutout: europe-2019-sarah3-era5-compressed
@@ -263,11 +268,7 @@ first_technology_occurrence:
     H2 Electrolysis: 2025
     H2 pipeline retrofitted: 2025
 
-renewable:
-  offwind-ac:
-    capacity_per_sqkm: 6
-  offwind-dc:
-    capacity_per_sqkm: 6
+
 
 costs:
   horizon: "mean" # "optimist", "pessimist" or "mean"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20240722newcutout
+  prefix: 20240731newcutout
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -82,6 +82,12 @@ existing_capacities:
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#countries
 # Germany plus 12 "Stromnachbarn"
 countries: ['AT', 'BE', 'CH', 'CZ', 'DE', 'DK', 'FR', 'GB', 'LU', 'NL', 'NO', 'PL', 'SE']
+
+# docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#snapshots
+snapshots:
+  start: "2019-01-01"
+  end: "2020-01-01"
+  inclusive: 'left'
 
 atlite:
   default_cutout: europe-2019-sarah3-era5-compressed

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20240710limitwasteheat
+  prefix: 20240722newcutout
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -83,6 +83,29 @@ existing_capacities:
 # Germany plus 12 "Stromnachbarn"
 countries: ['AT', 'BE', 'CH', 'CZ', 'DE', 'DK', 'FR', 'GB', 'LU', 'NL', 'NO', 'PL', 'SE']
 
+atlite:
+  default_cutout: europe-2019-sarah3-era5-compressed
+  cutouts:
+    europe-2019-sarah3-era5-compressed:
+      module: [sarah, era5] # in priority order
+      x: [-12., 42.]
+      y: [33., 72]
+      dx: 0.3
+      dy: 0.3
+      time: ['2019', '2019']
+renewable:
+  onwind:
+    cutout: europe-2019-sarah3-era5-compressed
+  offwind-ac:
+    cutout: europe-2019-sarah3-era5-compressed
+  offwind-dc:
+    cutout: europe-2019-sarah3-era5-compressed
+  offwind-float:
+    cutout: europe-2019-sarah3-era5-compressed
+  solar:
+    cutout: europe-2019-sarah3-era5-compressed
+  hydro:
+    cutout: europe-2019-sarah3-era5-compressed
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
 enable:
   retrieve: false # set to false once initial data is retrieved

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -104,8 +104,15 @@ renewable:
     cutout: europe-2019-sarah3-era5-compressed
   solar:
     cutout: europe-2019-sarah3-era5-compressed
+  solar-hsat:
+    cutout: europe-2019-sarah3-era5-compressed
   hydro:
     cutout: europe-2019-sarah3-era5-compressed
+
+lines:
+  dynamic_line_rating:
+    cutout: europe-2019-sarah3-era5-compressed
+
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#enable
 enable:
   retrieve: false # set to false once initial data is retrieved

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -413,7 +413,7 @@ rule plot_ariadne_variables:
 
 rule ariadne_all:
     input:
-        expand(RESULTS + "graphs/costs.pdf", run=config_provider("run", "name")),
+        expand(RESULTS + "graphs/costs.svg", run=config_provider("run", "name")),
         expand(RESULTS + "ariadne/capacity_detailed.png", run=config_provider("run", "name")),
         exported_variables=expand(RESULTS + "ariadne/exported_variables_full.xlsx", run=config_provider("run", "name")),
     script:


### PR DESCRIPTION
Updates the cutout for the weather data to 2019. At the moment this works only with the Cutout shared by Fabian

- [x] Wait for the publicly available zenodo cutout.
- [x] At the moment the `europe-2013` cutouts specified in the config.default.yaml in pypsa-eur still get downloaded by the workflow, even though they are not used. That's probably because the pypsa-ariadne config does not overwrite the list of available cutouts, but only extends it. We should find a way to deactivate that, else a few unnecessary GBs get downloaded