### PR TITLE
use NEP DC costs for offwind-connection

### DIFF
--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -11,4 +11,10 @@ HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
 HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
-HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
+offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"

--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -18,3 +18,5 @@ offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to 
 offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
 offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
 offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+offwind-float-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
+offwind-dc-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -11,4 +11,10 @@ HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
 HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
-HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
+offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -18,3 +18,5 @@ offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to 
 offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
 offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
 offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+offwind-float-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
+offwind-dc-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -11,4 +11,11 @@ HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
 HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
-HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
+offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -18,4 +18,6 @@ offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to 
 offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
 offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
 offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+offwind-float-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
+offwind-dc-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
 

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -11,4 +11,10 @@ HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
 HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
-HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
+offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -18,3 +18,5 @@ offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to 
 offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
 offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
 offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+offwind-float-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
+offwind-dc-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -11,4 +11,11 @@ HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
 HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
-HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
+offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -18,4 +18,6 @@ offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to 
 offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
 offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
 offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+offwind-float-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
+offwind-dc-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
 

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -11,4 +11,11 @@ HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
 HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
-HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
+offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -18,4 +18,6 @@ offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to 
 offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
 offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
 offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+offwind-float-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
+offwind-dc-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
 

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -11,4 +11,11 @@ HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
 HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
-HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
+offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -18,4 +18,6 @@ offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to 
 offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
 offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
 offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+offwind-float-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
+offwind-dc-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
 

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -11,4 +11,11 @@ HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023
 HVDC overhead,investment,995,EUR2020/MW/km,NEP2021+NEP2023
 HVDC submarine,investment,3234,EUR2020/MW/km,NEP2021
 HVAC overhead,investment,1215,EUR2020/MW/km,NEP2023
-HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023
+HVDC submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-float-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
+offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
+offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -18,4 +18,6 @@ offwind-dc-connection-submarine,investment,3183,EUR2020/MW/km,NEP2023,"equal to 
 offwind-dc-connection-underground,investment,3183,EUR2020/MW/km,NEP2023,"equal to HVDC underground"
 offwind-ac-connection-submarine,investment,4225,EUR2020/MW/km,NEP2023,"equal to AC underground"
 offwind-ac-connection-underground,investment,1215,EUR2020/MW/km,NEP2023,"equal to AC overhead"
+offwind-float-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
+offwind-dc-station,investment,700,EUR2020/kW,NEP2023,"cost of two stations"
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20240731highspatial
+  prefix: 20240801offwindconnectioncosts
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -13,7 +13,7 @@ run:
   # - KN2045plus_EasyRide
   # - KN2045plus_LowDemand
   # - KN2045minus_WorstCase
-  # - KN2045minus_SupplyFocus
+  - KN2045minus_SupplyFocus
   scenarios:
     enable: true
     manual_file: config/scenarios.manual.yaml

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -627,3 +627,7 @@ KN2045minus_SupplyFocus:
           2035: 215 # not forcing more EE
           2040: 215
           2045: 215
+  industry:
+    steam_biomass_fraction: 0.4
+    steam_hydrogen_fraction: 0.3
+    steam_electricity_fraction: 0.3

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -1017,7 +1017,7 @@ def get_primary_energy(n, region):
     ).multiply(MWh2PJ).sum()
 
     var["Primary Energy|Hydro"] = \
-        renewable_electricity.get([
+        renewable_electricity.reindex([
             "ror", "PHS", "hydro",
         ]).sum()
     


### PR DESCRIPTION
Our offwind connection investment is too low. I updated it to NEP23, however it still seems too low :thinking:. While I increased the input connection investment from ~2000 to ~3000 EUR/km/MW , and while capacities stayed the same, the output costs only increased by ~15%. 

I already fixed an issue in simplify network and double checked the exporter for bugs, but everything seems to be correct :thinking: So why is the costs increase so small? And why are the overall investments so low?



Before:
![Investment-Energy-Supply-Electricity-Transmission-Offwind-DC](https://github.com/user-attachments/assets/244d046f-dc70-4724-b6f3-6e4b1b0e477f)
After:
![Investment-Energy-Supply-Electricity-Transmission-Offwind-DC](https://github.com/user-attachments/assets/1a581687-9ae5-45fb-9b54-e8cdd5c4a2e5)

- [x] double check that the costs is ready correctly from the CSVs
- [x] check for bugs in exporter