### PR TITLE
Ignore pre-commit changes in `git blame`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Apply pre-commit (from #156)
+ca1f43c23f1c0936cb9f9e1062854fdf0060c409


### PR DESCRIPTION
Adds `.git-blame-ignore-revs` to ignore pre-commit changes from #156  in `git blame`.