### PR TITLE
Fix hydrogen import boundary condition

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Changelog
 
+- fix the hydrogen import boundary condition
 - add primary oil bus and account for refinery emissions
 - added Changelog file

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,7 +5,7 @@
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
 
-  prefix: 240806oilrefineries
+  prefix: 20240807fix_hydrogen_import_constraint
 
   name:
   # - CurrentPolicies

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -129,7 +129,11 @@ def h2_import_limits(n, investment_year, limits_volume_max):
         limit = limits_volume_max["h2_import"][ct][investment_year] * 1e6
 
         logger.info(f"limiting H2 imports in {ct} to {limit/1e6} TWh/a")
-        pipeline_carrier = ["H2 pipeline", "H2 pipeline (Kernnetz)", "H2 pipeline retrofitted"]
+        pipeline_carrier = [
+            "H2 pipeline",
+            "H2 pipeline (Kernnetz)",
+            "H2 pipeline retrofitted",
+        ]
         incoming = n.links.index[
             (n.links.carrier.isin(pipeline_carrier))
             & (n.links.bus0.str[:2] != ct)

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -129,14 +129,14 @@ def h2_import_limits(n, investment_year, limits_volume_max):
         limit = limits_volume_max["h2_import"][ct][investment_year] * 1e6
 
         logger.info(f"limiting H2 imports in {ct} to {limit/1e6} TWh/a")
-
+        pipeline_carrier = ["H2 pipeline", "H2 pipeline (Kernnetz)", "H2 pipeline retrofitted"]
         incoming = n.links.index[
-            (n.links.carrier == "H2 pipeline")
+            (n.links.carrier.isin(pipeline_carrier))
             & (n.links.bus0.str[:2] != ct)
             & (n.links.bus1.str[:2] == ct)
         ]
         outgoing = n.links.index[
-            (n.links.carrier == "H2 pipeline")
+            (n.links.carrier.isin(pipeline_carrier))
             & (n.links.bus0.str[:2] == ct)
             & (n.links.bus1.str[:2] != ct)
         ]

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -587,10 +587,10 @@ if __name__ == "__main__":
         snakemake = mock_snakemake(
             "modify_prenetwork",
             simpl="",
-            clusters=44,
+            clusters=22,
             opts="",
             ll="vopt",
-            sector_opts="None",
+            sector_opts="none",
             planning_horizons="2020",
             run="KN2045_Bal_v4",
         )


### PR DESCRIPTION
Closes https://github.com/PyPSA/pypsa-ariadne/issues/84

In `additional_functionality` a boundary condition is set by the function `h2_import_limits`.
However, so far only the carrier `H2 pipeline` was considered.
Since there could also be the carriers `H2 pipeline (Kernnetz)` and `H2 pipeline retrofitted`, the query for the incoming and outgoing flow links is changed minor.
The boundary condition works even when Kernnetz and retrofitting is not activated.

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [x] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptivetitle

There are no changes to the export_araidne_variables rule
The figures did not change since `H2_retrofit` and `Kernnetz` are currently not enabled.