### PR TITLE
Limit German CO2 sequestration in each investment year

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20240731highspatial
+  prefix: 240813-with_de_co2_seq_limit
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -160,6 +160,16 @@ limits_capacity_max:
         2035: 400
         2040: 400
         2045: 400
+
+  Store:
+    co2 sequestered:
+      DE:
+        2020: 0
+        2025: 0
+        2030: 10000
+        2035: 20000
+        2040: 40000
+        2045: 50000
 
 limits_capacity_min:
     Generator:


### PR DESCRIPTION
Extend the functions `add_{min/max}_limits` in `additional_functionality.py` to allow stores.

Add limits to DE CO2 sequestration based on feasibility constraints.

E.g. since EU target for 2030 is 50 MtCO2/a sequestration in Net Zero Industry Act, limit DE to 10 MtCO2/a, then relax with subsequent years.

For 365H resolution, this limit reduced sequestration in DE in 2030 from 55 to 10 MtCO2, while increasing system costs by 0.3%. The limit in 2045 reduced sequestration in DE from 97 to 50 MtCO2, while increasing system costs by 2.5%.


Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [x] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
