### PR TITLE
 Limit German CO2 sequestration in each investment year

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20240809withSpain
+  prefix: 20240814limitseq
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -376,6 +376,15 @@ solving:
             2035: 400
             2040: 400
             2045: 400
+      Store:
+        co2 sequestered:
+          DE:
+            2020: 0
+            2025: 0
+            2030: 10000
+            2035: 20000
+            2040: 50000
+            2045: 80000
     limits_capacity_min:
       Generator:
         onwind:

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -54,6 +54,12 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
 
                 cname = f"capacity_{sense}-{ct}-{c.name}-{carrier.replace(' ','-')}"
 
+                if cname in n.global_constraints.index:
+                    logger.warning(
+                        f"Global constraint {cname} already exists. Skipping."
+                    )
+                    continue
+
                 if sense == "maximum":
                     if limit - existing_capacity <= 0:
                         n.model.add_constraints(
@@ -75,16 +81,6 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                 else:
                     logger.error("sense {sense} not recognised")
                     sys.exit()
-
-                if cname not in n.global_constraints.index:
-                    n.add(
-                        "GlobalConstraint",
-                        cname,
-                        constant=limit,
-                        sense="<=" if sense == "maximum" else ">=",
-                        type="",
-                        carrier_attribute="",
-                    )
 
 
 def h2_import_limits(n, investment_year, limits_volume_max):

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -20,10 +20,7 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
         for carrier in limits_capacity[c.name]:
 
             for ct in limits_capacity[c.name][carrier]:
-                if (
-                    investment_year
-                    not in limits_capacity[c.name][carrier][ct].keys()
-                ):
+                if investment_year not in limits_capacity[c.name][carrier][ct].keys():
                     continue
 
                 limit = 1e3 * limits_capacity[c.name][carrier][ct][investment_year]
@@ -38,8 +35,12 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                     & ~c.df.carrier.str.contains("thermal")
                 )  # exclude solar thermal
 
-                existing_index = c.df.index[valid_components & ~c.df[attr + "_nom_extendable"]]
-                extendable_index = c.df.index[valid_components & c.df[attr + "_nom_extendable"]]
+                existing_index = c.df.index[
+                    valid_components & ~c.df[attr + "_nom_extendable"]
+                ]
+                extendable_index = c.df.index[
+                    valid_components & c.df[attr + "_nom_extendable"]
+                ]
 
                 existing_capacity = c.df.loc[existing_index, attr + "_nom"].sum()
 
@@ -55,7 +56,9 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
 
                 if sense == "maximum":
                     if limit - existing_capacity <= 0:
-                        n.model.add_constraints(lhs <= 0, name=f"GlobalConstraint-{cname}")
+                        n.model.add_constraints(
+                            lhs <= 0, name=f"GlobalConstraint-{cname}"
+                        )
                         logger.warning(
                             f"Existing capacity in {ct} for carrier {carrier} already exceeds the limit of {limit} MW. Limiting capacity expansion for this investment period to 0."
                         )
@@ -66,7 +69,8 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                         )
                 elif sense == "minimum":
                     n.model.add_constraints(
-                        lhs >= limit - existing_capacity, name=f"GlobalConstraint-{cname}"
+                        lhs >= limit - existing_capacity,
+                        name=f"GlobalConstraint-{cname}",
                     )
                 else:
                     logger.error("sense {sense} not recognised")
@@ -81,7 +85,6 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                         type="",
                         carrier_attribute="",
                     )
-
 
 
 def h2_import_limits(n, investment_year, limits_volume_max):
@@ -532,9 +535,13 @@ def additional_functionality(n, snapshots, snakemake):
     investment_year = int(snakemake.wildcards.planning_horizons[-4:])
     constraints = snakemake.params.solving["constraints"]
 
-    add_capacity_limits(n, investment_year, constraints["limits_capacity_min"], "minimum")
+    add_capacity_limits(
+        n, investment_year, constraints["limits_capacity_min"], "minimum"
+    )
 
-    add_capacity_limits(n, investment_year, constraints["limits_capacity_max"], "maximum")
+    add_capacity_limits(
+        n, investment_year, constraints["limits_capacity_max"], "maximum"
+    )
 
     if int(snakemake.wildcards.clusters) != 1:
         h2_import_limits(n, investment_year, constraints["limits_volume_max"])


### PR DESCRIPTION
Unify functions `add_{min/max}_capacity` in `additional_functionality.py` to avoid boilerplate code repetition.

Allow this function to limit stores.

Add limits to DE CO2 sequestration based on feasibility constraints.

E.g. since EU target for 2030 is 50 MtCO2/a sequestration in Net Zero Industry Act, limit DE to 10 MtCO2/a, then relax with subsequent years.

For 365H resolution, this limit reduced sequestration in DE in 2030 from 55 to 10 MtCO2, while increasing system costs by 0.3%. The limit in 2045 reduced sequestration in DE from 97 to 80 MtCO2, while increasing system costs by 0.3%.

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [x] The logic of `export_ariadne_variables` has been adapted to the changes
- [x] One or several numbers that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
