### PR TITLE
Capacity Reduction for Kernnetz not necessary

### DIFF
--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -243,8 +243,6 @@ def add_wasserstoff_kernnetz(n, wkn, costs):
     # pipelines which are being build in total (more conservative approach)
     if not wkn.empty and snakemake.params.H2_retrofit:
 
-        conversion_rate = snakemake.params.H2_retrofit_capacity_per_CH4
-
         retrofitted_b = (
             n.links.carrier == "H2 pipeline retrofitted"
         ) & n.links.index.str.contains(str(investment_year))
@@ -256,7 +254,6 @@ def add_wasserstoff_kernnetz(n, wkn, costs):
                 add_reversed_pipes(wkn),
                 carrier="H2",
                 target_attr="p_nom_max",
-                conversion_rate=conversion_rate,
             )
             n.links.loc[retrofitted_b, "p_nom_max"] = res_h2_pipes_retrofitted[
                 "p_nom_max"


### PR DESCRIPTION
In `prepare_sector_network` in `add_storage_and_grids` if `config["sector"]["H2_retrofit"]` the variable `p_nom_extendable` is already multiplied by the `options["H2_retrofit_capacity_per_CH4"]` factor.
This means that multiplying it again in `modify_prenetwork` is not necessary.

**Only bugfix, so none of the points below are done.**

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
