### PR TITLE
Report coke emissions in energy supply

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -339,6 +339,13 @@ industry:
     2040: 0.4
     2045: 0.35
     2050: 0.3
+  DRI_fraction:
+    2020: 0
+    2025: 0
+    2030: 0.05
+    2035: 0.3
+    2040: 0.6
+    2045: 1
 #HVC primary/recycling based on values used in Neumann et al https://doi.org/10.1016/j.joule.2023.06.016, linearly interpolated between 2020 and 2050
 #2020 recycling rates based on Agora https://static.agora-energiewende.de/fileadmin/Projekte/2021/2021_02_EU_CEAP/A-EW_254_Mobilising-circular-economy_study_WEB.pdf
 #fractions refer to the total primary HVC production in 2020

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -2623,12 +2623,13 @@ def get_emissions(n, region, _energy_totals, industry_demand, costs):
     # TODO where should the methanol go?
     mwh_coal_per_mwh_coke = 1.366  # from eurostat energy balance
 
+    # 0.3361 t/MWh, industry_DE is in PJ, 1e-6 to convert to Mt
     var["Emissions|CO2|Energy|Demand|Industry"] = co2_emissions.reindex(
         ["gas for industry", "gas for industry CC", "coal for industry"]
     ).sum() - co2_atmosphere_withdrawal.get(
         "solid biomass for industry CC",
         0,
-    ) - industry_DE.coke * (mwh_coal_per_mwh_coke - 1) * costs.at["coal", "CO2 intensity"]
+    ) - industry_DE.coke * (mwh_coal_per_mwh_coke - 1) * (0.3361 / MWh2PJ * 1e-6)
 
     var["Emissions|CO2|Industry"] = (
         var["Emissions|CO2|Energy|Demand|Industry"]
@@ -2737,8 +2738,8 @@ def get_emissions(n, region, _energy_totals, industry_demand, costs):
     var["Emissions|CO2|Energy|Supply|Gases"] = (-1) * co2_atmosphere_withdrawal.filter(
         like="biogas to gas"
     ).sum()
-
-    var["Emissions|CO2|Energy|Supply|Solids"] = industry_DE.coke * (mwh_coal_per_mwh_coke - 1) * costs.at["coal", "CO2 intensity"]
+    # 0.3361 t/MWh, industry_DE is in PJ, 1e-6 to convert to Mt
+    var["Emissions|CO2|Energy|Supply|Solids"] = industry_DE.coke * (mwh_coal_per_mwh_coke - 1) * (0.3361 / MWh2PJ * 1e-6)
 
     var["Emissions|CO2|Supply|Non-Renewable Waste"] = (
         co2_emissions.get("HVC to air").sum() + waste_CHP_emissions.sum()

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -2359,7 +2359,7 @@ def get_final_energy(
     return var
 
 
-def get_emissions(n, region, _energy_totals, industry_demand, costs):
+def get_emissions(n, region, _energy_totals, industry_demand):
     energy_totals = _energy_totals.loc[region[0:2]]
 
     industry_DE = industry_demand.filter(
@@ -2632,7 +2632,7 @@ def get_emissions(n, region, _energy_totals, industry_demand, costs):
                 "coal for industry",
             ]
         ).sum()
-    ) - industry_DE.coke * (mwh_coal_per_mwh_coke - 1) * (0.3361 / MWh2PJ * 1e-6)
+    ) - industry_DE.coke / MWh2PJ * (mwh_coal_per_mwh_coke - 1) * 0.3361  * t2Mt
     var["Emissions|CO2|Energy|Demand|Industry"] = var[
         "Emissions|Gross Fossil CO2|Energy|Demand|Industry"
     ] - co2_atmosphere_withdrawal.get("solid biomass for industry CC", 0)
@@ -2746,7 +2746,7 @@ def get_emissions(n, region, _energy_totals, industry_demand, costs):
     ).sum()
     # 0.3361 t/MWh, industry_DE is in PJ, 1e-6 to convert to Mt
     var["Emissions|CO2|Energy|Supply|Solids"] = (
-        industry_DE.coke * (mwh_coal_per_mwh_coke - 1) * (0.3361 / MWh2PJ * 1e-6)
+        industry_DE.coke / MWh2PJ * (mwh_coal_per_mwh_coke - 1) * 0.3361  * t2Mt
     )
 
     var["Emissions|CO2|Supply|Non-Renewable Waste"] = (
@@ -4209,7 +4209,7 @@ def get_ariadne_var(
                 industry_production,
             ),
             get_prices(n, region),
-            get_emissions(n, region, energy_totals, industry_demand, costs),
+            get_emissions(n, region, energy_totals, industry_demand),
             get_grid_investments(
                 n,
                 costs,

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -2633,10 +2633,9 @@ def get_emissions(n, region, _energy_totals, industry_demand, costs):
             ]
         ).sum()
     ) - industry_DE.coke * (mwh_coal_per_mwh_coke - 1) * (0.3361 / MWh2PJ * 1e-6)
-    var["Emissions|CO2|Energy|Demand|Industry"] = (
-        var["Emissions|Gross Fossil CO2|Energy|Demand|Industry"]
-        - co2_atmosphere_withdrawal.get("solid biomass for industry CC", 0)
-    )
+    var["Emissions|CO2|Energy|Demand|Industry"] = var[
+        "Emissions|Gross Fossil CO2|Energy|Demand|Industry"
+    ] - co2_atmosphere_withdrawal.get("solid biomass for industry CC", 0)
 
     var["Emissions|CO2|Industry"] = (
         var["Emissions|CO2|Energy|Demand|Industry"]
@@ -2746,20 +2745,25 @@ def get_emissions(n, region, _energy_totals, industry_demand, costs):
         like="biogas to gas"
     ).sum()
     # 0.3361 t/MWh, industry_DE is in PJ, 1e-6 to convert to Mt
-    var["Emissions|CO2|Energy|Supply|Solids"] = industry_DE.coke * (mwh_coal_per_mwh_coke - 1) * (0.3361 / MWh2PJ * 1e-6)
+    var["Emissions|CO2|Energy|Supply|Solids"] = (
+        industry_DE.coke * (mwh_coal_per_mwh_coke - 1) * (0.3361 / MWh2PJ * 1e-6)
+    )
 
     var["Emissions|CO2|Supply|Non-Renewable Waste"] = (
         co2_emissions.get("HVC to air").sum() + waste_CHP_emissions.sum()
     )
 
-    var["Emissions|Gross Fossil CO2|Energy|Supply|Liquids"] = \
-        co2_emissions.get("oil refining", 0)
+    var["Emissions|Gross Fossil CO2|Energy|Supply|Liquids"] = co2_emissions.get(
+        "oil refining", 0
+    )
 
-    var["Emissions|CO2|Energy|Supply|Liquids"] = \
-        var["Emissions|Gross Fossil CO2|Energy|Supply|Liquids"]
+    var["Emissions|CO2|Energy|Supply|Liquids"] = var[
+        "Emissions|Gross Fossil CO2|Energy|Supply|Liquids"
+    ]
 
-    var["Emissions|CO2|Energy|Supply|Liquids and Gases"] = \
-        var["Emissions|CO2|Energy|Supply|Liquids"] # no gases at the moment
+    var["Emissions|CO2|Energy|Supply|Liquids and Gases"] = var[
+        "Emissions|CO2|Energy|Supply|Liquids"
+    ]  # no gases at the moment
 
     var["Emissions|Gross Fossil CO2|Energy|Supply"] = (
         var["Emissions|Gross Fossil CO2|Energy|Supply|Electricity"]
@@ -2818,7 +2822,6 @@ def get_emissions(n, region, _energy_totals, industry_demand, costs):
     assert abs(emission_difference) < 1e-5
 
     return var
-
 
 
 # functions for prices

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -2361,12 +2361,11 @@ def get_final_energy(
 
 def get_emissions(n, region, _energy_totals, industry_demand, costs):
     energy_totals = _energy_totals.loc[region[0:2]]
-    print(industry_demand.head())
+
     industry_DE = industry_demand.filter(
         like=region,
         axis=0,
     ).sum()
-    print(industry_DE)
 
     kwargs = {
         "groupby": n.statistics.groupers.get_name_bus_and_carrier,


### PR DESCRIPTION
The emissions of coke for industry were so far completely assigned to the industry sector.
The production of coke from coal leads to inevitable emissions which are now reported with the variable `Emissions|CO2|Energy|Supply`.

Furthermore, the share of `DRI steel` is adjusted following the [Treibhausprojektion](https://www.umweltbundesamt.de/sites/default/files/medien/11850/publikationen/projektionen_technischer_anhang_0.pdf) by uba.

![image](https://github.com/user-attachments/assets/dea016fb-eaa1-4665-8ba9-83756d014c50)


Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [x] The logic of `export_ariadne_variables` has been adapted to the changes
- [x] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
_only exporter changes_
- [x] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
_only exporter changes_
