### PR TITLE
Assume all new lines are HTLS

### DIFF
--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -8,10 +8,10 @@ decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadne
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
 HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
 HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
-offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
-offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-underground,investment,558,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
+offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,
+offwind-ac-connection-underground,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-station,investment,697,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-ac-station,investment,722,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
 HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023

--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -26,4 +26,4 @@ offwind-dc-connection-underground,investment,3234,EUR2020/MW/km,NEP2021,"DC 525k
 offwind-dc-connection-underground,investment,3430,EUR2020/MW/km,NEP2023,"DC 525kv landseitig"
 offwind-dc-station,investment,746,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-dc-station,investment,903,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
-    
+

--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 M
 decentral air-sourced heat pump,investment,1685,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,732,EUR2020/MW/km,NEP2021,
-HVAC overhead,investment,1196,EUR2020/MW/km,NEP2023,
+HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
 offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,
@@ -26,3 +26,4 @@ offwind-dc-connection-underground,investment,3234,EUR2020/MW/km,NEP2021,"DC 525k
 offwind-dc-connection-underground,investment,3430,EUR2020/MW/km,NEP2023,"DC 525kv landseitig"
 offwind-dc-station,investment,746,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-dc-station,investment,903,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
+    

--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -26,4 +26,3 @@ offwind-dc-connection-underground,investment,3234,EUR2020/MW/km,NEP2021,"DC 525k
 offwind-dc-connection-underground,investment,3430,EUR2020/MW/km,NEP2023,"DC 525kv landseitig"
 offwind-dc-station,investment,746,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-dc-station,investment,903,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
-

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -8,10 +8,10 @@ decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadne
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
 HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
 HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
-offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
-offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-underground,investment,558,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
+offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,
+offwind-ac-connection-underground,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-station,investment,697,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-ac-station,investment,722,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
 HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 M
 decentral air-sourced heat pump,investment,1685,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,732,EUR2020/MW/km,NEP2021,
-HVAC overhead,investment,1196,EUR2020/MW/km,NEP2023,
+HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
 offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 M
 decentral air-sourced heat pump,investment,1604,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2682,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,732,EUR2020/MW/km,NEP2021,
-HVAC overhead,investment,1196,EUR2020/MW/km,NEP2023,
+HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
 offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -8,10 +8,10 @@ decentral ground-sourced heat pump,investment,2682,EUR2020/kW_th,https://ariadne
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
 HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
 HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
-offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
-offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-underground,investment,558,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
+offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,
+offwind-ac-connection-underground,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-station,investment,697,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-ac-station,investment,722,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
 HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,1083,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 M
 decentral air-sourced heat pump,investment,1523,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2589,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,732,EUR2020/MW/km,NEP2021,
-HVAC overhead,investment,1196,EUR2020/MW/km,NEP2023,
+HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
 offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -8,10 +8,10 @@ decentral ground-sourced heat pump,investment,2589,EUR2020/kW_th,https://ariadne
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
 HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
 HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
-offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
-offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-underground,investment,558,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
+offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,
+offwind-ac-connection-underground,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-station,investment,697,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-ac-station,investment,722,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
 HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,900,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW
 decentral air-sourced heat pump,investment,1483,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2497,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,732,EUR2020/MW/km,NEP2021,
-HVAC overhead,investment,1196,EUR2020/MW/km,NEP2023,
+HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
 offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -8,10 +8,10 @@ decentral ground-sourced heat pump,investment,2497,EUR2020/kW_th,https://ariadne
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
 HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
 HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
-offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
-offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-underground,investment,558,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
+offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,
+offwind-ac-connection-underground,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-station,investment,697,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-ac-station,investment,722,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
 HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -8,10 +8,10 @@ decentral ground-sourced heat pump,investment,2404,EUR2020/kW_th,https://ariadne
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
 HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
 HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
-offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
-offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-underground,investment,558,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
+offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,
+offwind-ac-connection-underground,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-station,investment,697,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-ac-station,investment,722,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
 HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,717,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW
 decentral air-sourced heat pump,investment,1442,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2404,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,732,EUR2020/MW/km,NEP2021,
-HVAC overhead,investment,1196,EUR2020/MW/km,NEP2023,
+HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
 offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -8,10 +8,10 @@ decentral ground-sourced heat pump,investment,2312,EUR2020/kW_th,https://ariadne
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
 HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
 HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
-offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
-offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-underground,investment,558,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
+offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,
+offwind-ac-connection-underground,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-station,investment,697,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-ac-station,investment,722,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
 HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,533,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW
 decentral air-sourced heat pump,investment,1402,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2312,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,732,EUR2020/MW/km,NEP2021,
-HVAC overhead,investment,1196,EUR2020/MW/km,NEP2023,
+HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
 offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -8,10 +8,10 @@ decentral ground-sourced heat pump,investment,2219,EUR2020/kW_th,https://ariadne
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
 HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
 HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
-offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
-offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,
-offwind-ac-connection-underground,investment,558,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
+offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
+offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,
+offwind-ac-connection-underground,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-station,investment,697,EUR2020/kW,NEP2021,"cost of two stations, landseitig and seeseitig"
 offwind-ac-station,investment,722,EUR2020/kW,NEP2023,"cost of two stations, landseitig and seeseitig"
 HVDC inverter pair,investment,597015,EUR2020/MW,NEP2021+NEP2023

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,350,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW
 decentral air-sourced heat pump,investment,1362,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2219,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,732,EUR2020/MW/km,NEP2021,
-HVAC overhead,investment,1196,EUR2020/MW/km,NEP2023,
+HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,850,EUR2020/MW/km,NEP2021,
 offwind-ac-connection-submarine,investment,558,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,850,EUR2020/MW/km,NEP2021,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20240926_add_existing_update
+  prefix: 20240926_htls_costs
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -2630,7 +2630,9 @@ def get_emissions(n, region, _energy_totals, industry_demand):
 
     mwh_coal_per_mwh_coke = 1.366  # from eurostat energy balance
     # 0.3361 t/MWh, industry_DE is in PJ, 1e-6 to convert to Mt
-    coking_emissions = industry_DE.coke / MWh2PJ * (mwh_coal_per_mwh_coke - 1) * 0.3361  * t2Mt
+    coking_emissions = (
+        industry_DE.coke / MWh2PJ * (mwh_coal_per_mwh_coke - 1) * 0.3361 * t2Mt
+    )
     var["Emissions|Gross Fossil CO2|Energy|Demand|Industry"] = (
         co2_emissions.reindex(
             [
@@ -2640,8 +2642,9 @@ def get_emissions(n, region, _energy_totals, industry_demand):
             ]
         ).sum()
     ) - coking_emissions
-    var["Emissions|Gross Fossil CO2|Energy|Supply|Solids"] = \
-    var["Emissions|CO2|Energy|Supply|Solids"] = coking_emissions
+    var["Emissions|Gross Fossil CO2|Energy|Supply|Solids"] = var[
+        "Emissions|CO2|Energy|Supply|Solids"
+    ] = coking_emissions
 
     var["Emissions|CO2|Energy|Demand|Industry"] = var[
         "Emissions|Gross Fossil CO2|Energy|Demand|Industry"
@@ -2754,7 +2757,6 @@ def get_emissions(n, region, _energy_totals, industry_demand):
     var["Emissions|CO2|Energy|Supply|Gases"] = (-1) * co2_atmosphere_withdrawal.filter(
         like="biogas to gas"
     ).sum()
-
 
     var["Emissions|CO2|Supply|Non-Renewable Waste"] = (
         co2_emissions.get("HVC to air").sum() + waste_CHP_emissions.sum()


### PR DESCRIPTION
HTLS have higher Ampere, thus updating NEP costs yet again.

For NEP 2021

![image](https://github.com/user-attachments/assets/bfc27068-a2c7-4ccd-821a-e5b1d5212b17)

HVAC:

Neubau = 2.5M€/km, HTLS Addon = 0.2M€/km , Ampere = 4000, Volts = 380

2.7 M/km / (380k * 4k * sqrt(3) * 2) = 513 € / MWkm -> Inflation: 1.005: 510

offwind-ac: Ampere = 1000, Volts = 220

For NEP 2023

HVAC:

Neubau = 4.5M€/km, rest stays the same -> 893€/km -> Inflation: 1.108 -> 806


More info at: https://github.com/PyPSA/pypsa-ariadne/pull/193

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
