### PR TITLE
Another update for HVAC-Hochstrom costs

### DIFF
--- a/ariadne-data/costs_2019-modifications.csv
+++ b/ariadne-data/costs_2019-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 M
 decentral air-sourced heat pump,investment,1685,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
-HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,472,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,772,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
 offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2020-modifications.csv
+++ b/ariadne-data/costs_2020-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,1450,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 M
 decentral air-sourced heat pump,investment,1685,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 decentral ground-sourced heat pump,investment,2774,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
-HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,472,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,772,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
 offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2025-modifications.csv
+++ b/ariadne-data/costs_2025-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,1267,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 M
 decentral air-sourced heat pump,investment,1604,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2682,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
-HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,472,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,772,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
 offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2030-modifications.csv
+++ b/ariadne-data/costs_2030-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,1083,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 M
 decentral air-sourced heat pump,investment,1523,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2589,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
-HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,472,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,772,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
 offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2035-modifications.csv
+++ b/ariadne-data/costs_2035-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,900,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW
 decentral air-sourced heat pump,investment,1483,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2497,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
-HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,472,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,772,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
 offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2040-modifications.csv
+++ b/ariadne-data/costs_2040-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,717,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW
 decentral air-sourced heat pump,investment,1442,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2404,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
-HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,472,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,772,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
 offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2045-modifications.csv
+++ b/ariadne-data/costs_2045-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,533,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW
 decentral air-sourced heat pump,investment,1402,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2312,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
-HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,472,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,772,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
 offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,

--- a/ariadne-data/costs_2050-modifications.csv
+++ b/ariadne-data/costs_2050-modifications.csv
@@ -6,8 +6,8 @@ electrolysis,investment,350,EUR2020/kW_e,DEA,"linear interpolation of AEC 100 MW
 decentral air-sourced heat pump,investment,1362,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 decentral ground-sourced heat pump,investment,2219,EUR2020/kW_th,https://ariadneprojekt.de/media/2024/01/Ariadne-Analyse_HeizkostenEmissionenGebaeude_Januar2024.pdf https://www.enpal.de/waermepumpe/kosten/ https://www.bdew.de/media/documents/BDEW-HKV_Altbau.pdf and cost reduction from DEA
 electricity distribution grid,investment,1500,EUR2020/kW,Tom's expert opinion
-HVAC overhead,investment,510,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
-HVAC overhead,investment,806,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,472,EUR2020/MW/km,NEP2021,"Assuming High Temperature Low Sag Cables with higher Amperage"
+HVAC overhead,investment,772,EUR2020/MW/km,NEP2023,"Assuming High Temperature Low Sag Cables with higher Amperage"
 offwind-ac-connection-submarine,investment,3786,EUR2020/MW/km,NEP2021,"220kv, 1A, 2 circuits, 3 phases, inflation"
 offwind-ac-connection-submarine,investment,2488,EUR2020/MW/km,NEP2023,
 offwind-ac-connection-underground,investment,3786,EUR2020/MW/km,NEP2021,


### PR DESCRIPTION
Improves over https://github.com/PyPSA/pypsa-ariadne/pull/206 because actually no cost add on of 0.2m€/km needed, since the orginal Neubau costs are already for "Hochstrom", which is 4kA.

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
