### PR TITLE
Fix capacity constraints for post discretization

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -398,11 +398,11 @@ solving:
   options:
     assign_all_duals: true
     load_shedding: false
-    skip_iterations: false # settings for post-discretization: false
+    skip_iterations: true # settings for post-discretization: false
     min_iterations: 1 # settings for post-discretization: 1
     max_iterations: 1 # settings for post-discretization: 1
     post_discretization:
-      enable: true
+      enable: false
       line_unit_size: 1700
       line_threshold: 0.3
       link_unit_size:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,9 +4,9 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241001ElecValidationUpdate
+  prefix: 20241002_fix_post_discretization_constraints
   name:
-  # - CurrentPolicies
+  - CurrentPolicies
   - KN2045_Bal_v4
   # - KN2045_Elec_v4
   # - KN2045_H2_v4
@@ -398,11 +398,11 @@ solving:
   options:
     assign_all_duals: true
     load_shedding: false
-    skip_iterations: true # settings for post-discretization: false
+    skip_iterations: false # settings for post-discretization: false
     min_iterations: 1 # settings for post-discretization: 1
     max_iterations: 1 # settings for post-discretization: 1
     post_discretization:
-      enable: false
+      enable: true
       line_unit_size: 1700
       line_threshold: 0.3
       link_unit_size:

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -56,9 +56,9 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
 
                 if cname in n.global_constraints.index:
                     logger.warning(
-                        f"Global constraint {cname} already exists. Skipping."
+                        f"Global constraint {cname} already exists. Dropping and adding it again."
                     )
-                    continue
+                    n.global_constraints.drop(cname, inplace=True)
 
                 if sense == "maximum":
                     if limit - existing_capacity <= 0:


### PR DESCRIPTION
With the post discretization the capacity constraints were not active for the second optimization since they already existed in `n.globalconstraints` but are not present in `n.model`.

Validation Balance Scenario
![image](https://github.com/user-attachments/assets/c0a40aee-2702-4f4f-84f3-1eaaa8d38e2c)

Validation Current Policies Scenario
![image](https://github.com/user-attachments/assets/c258b0e5-057f-40ae-ac65-4dd6d2c5a3b6)


Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
_assertion error in `hack_transmission_grid`_
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
_not applicable_
- [x] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
_bugfix_
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
