### PR TITLE
Solar Correction Factor

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Changelog
+- adjusting capacity factor of solar to match historic data
 - updated the Kernnetz to use latest data and operate it more flexible
 - added Italy with 3 additional nodes
 - adapted spatial distribution of district heating demand in Germany according to data from eGo^N project

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241007_merge_master
+  prefix: 20241008_solar_cf
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -174,8 +174,10 @@ renewable:
     cutout: europe-2019-sarah3-era5
   solar:
     cutout: europe-2019-sarah3-era5
+    correction_factor: 0.86
   solar-hsat:
     cutout: europe-2019-sarah3-era5
+    correction_factor: 0.86
   hydro:
     cutout: europe-2019-sarah3-era5
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -174,10 +174,10 @@ renewable:
     cutout: europe-2019-sarah3-era5
   solar:
     cutout: europe-2019-sarah3-era5
-    correction_factor: 0.86
+    correction_factor: 0.918
   solar-hsat:
     cutout: europe-2019-sarah3-era5
-    correction_factor: 0.86
+    correction_factor: 0.918
   hydro:
     cutout: europe-2019-sarah3-era5
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -176,10 +176,10 @@ renewable:
     cutout: europe-2019-sarah3-era5
   solar:
     cutout: europe-2019-sarah3-era5
-    correction_factor: 0.918
+    correction_factor: 0.918 # scaling to Abbildung 36 of https://www.ise.fraunhofer.de/de/veroeffentlichungen/studien/aktuelle-fakten-zur-photovoltaik-in-deutschland.html
   solar-hsat:
     cutout: europe-2019-sarah3-era5
-    correction_factor: 0.918
+    correction_factor: 0.918 # scaling to Abbildung 36 of https://www.ise.fraunhofer.de/de/veroeffentlichungen/studien/aktuelle-fakten-zur-photovoltaik-in-deutschland.html
   hydro:
     cutout: europe-2019-sarah3-era5
 


### PR DESCRIPTION
# Issue
Addressing https://github.com/PyPSA/pypsa-ariadne/issues/224

Adding a correction factor for solar to `correction_factor = 0.86` to limit the electricity generation from solar.
Modelling to target so 2020 results match the historical data.

## Validation
Full load hours before PR: 1071.5
Full load hours with PR: 921.3

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
_not applicable_
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
_not applicable_
- [x] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
