### PR TITLE
Restricting powerflow from and to Germany

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241007_merge_master
+  prefix: 20241008_restrict_power_flow
   name:
   # - CurrentPolicies
   - KN2045_Bal_v4
@@ -553,6 +553,17 @@ solving:
           2035: 0
           2040: 0
           2045: 0
+    limits_power_max: # in GW
+        DE:
+          2020: 15
+          2025: 15
+          2030: 15
+          2035: 20
+          2040: 25
+          2045: 30
+  solver:
+    gurobi-default:
+      BarConvTol: 1.e-4
   # solver:
   #   options: gurobi-numeric-focus
   # solver_options:

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -100,6 +100,61 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                     sys.exit()
 
 
+def add_power_limits(n, investment_year, limits_power_max):
+    """"
+    Restricts the maximum inflow/outflow of electricity from/to a country
+    """
+    for ct in limits_power_max:
+        if investment_year not in limits_power_max[ct].keys():
+            continue
+
+        limit = 1e3 * limits_power_max[ct][investment_year]
+
+        logger.info(
+            f"Adding constraint on electricity import/export from/to {ct} to be < {limit} MW"
+        )
+        incoming_line = n.lines.index[
+            (n.lines.carrier == "AC")
+            & (n.lines.bus0.str[:2] != ct)
+            & (n.lines.bus1.str[:2] == ct)
+        ]
+        outgoing_line = n.lines.index[
+            (n.lines.carrier == "AC")
+            & (n.lines.bus0.str[:2] == ct)
+            & (n.lines.bus1.str[:2] != ct)
+        ]
+
+        incoming_link = n.links.index[
+            (n.links.carrier == "DC")
+            & (n.links.bus0.str[:2] != ct)
+            & (n.links.bus1.str[:2] == ct)
+        ]
+        outgoing_link = n.links.index[
+            (n.links.carrier == "DC")
+            & (n.links.bus0.str[:2] == ct)
+            & (n.links.bus1.str[:2] != ct)
+        ]
+
+        # iterate over snapshots - otherwise exporting of postnetwork fails since
+        # the constraints are time dependent
+        for t in n.snapshots:
+            incoming_line_p = n.model["Line-s"].loc[t, incoming_line]
+            outgoing_line_p = n.model["Line-s"].loc[t, outgoing_line]
+            incoming_link_p = n.model["Link-p"].loc[t, incoming_link]
+            outgoing_link_p = n.model["Link-p"].loc[t, outgoing_link]
+
+            lhs = incoming_link_p.sum() - outgoing_link_p.sum() + incoming_line_p.sum() - outgoing_line_p.sum()
+            # divide by 10 - 100 to avoid numerical issues
+
+            cname_upper = f"Power-import-limit-{ct}-{t}"
+            cname_lower = f"Power-export-limit-{ct}-{t}"
+
+            n.model.add_constraints(lhs <= limit, name=cname_upper)
+            n.model.add_constraints(lhs >= -limit, name=cname_lower)
+
+            # not adding to network as the shadow prices are not needed
+
+
 def h2_import_limits(n, investment_year, limits_volume_max):
 
     for ct in limits_volume_max["h2_import"]:
@@ -613,6 +668,10 @@ def additional_functionality(n, snapshots, snakemake):
 
     add_capacity_limits(
         n, investment_year, constraints["limits_capacity_max"], "maximum"
+    )
+
+    add_power_limits(
+        n, investment_year, constraints["limits_power_max"]
     )
 
     if int(snakemake.wildcards.clusters) != 1:


### PR DESCRIPTION
### Issue
Germany has a net restriction for the import of electricity, however we observed timesteps with a unrealistic high import power flow.

### Solution
In the `config["solving"]["constraints"]["limits_power_max"]` values for Germany for the import/export flow are specified.
The maximum power import/export is set to 15 GW and increases beginning from 2030 linear until 2045 to 30 GW.

### Annotations
The constraint is set for each timestep, since adding it as one leads to errors while exporting the postnetwork. This is due to the time dependent nature of the constraint that would need a unique name for each constraint anyway.
The constraint is not added to `n.global_constraints` due to that reason because it would overload the `n.global_constraints` with `8760 / time_resolution` constraints. Since the shadow prices of those import/export constraints are not important at the moment, this is tolerated.

### Numerical Issues
In the 2020 optimization (with and without postdiscretization), there are numerical instabilites observed.
This could be due to:
- the constraint to satisfy Kirchhoffs voltage law (high imports/exports at one connection could lead to trouble in the circuits)
- Gurobi BarConvTol which is currently 1e-6 and could be increased to 1e-4
- Large bounds of the constraint which can be counteracted by dividing the lhs and rhs by 10

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
