### PR TITLE
Restricting Current Policies scenario

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,10 +4,10 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241017_pypsa31
+  prefix: 20241021_fix_CurrentPolicies
   name:
-  # - CurrentPolicies
-  - KN2045_Bal_v4
+  - CurrentPolicies
+  # - KN2045_Bal_v4
   # - KN2045_Elec_v4
   # - KN2045_H2_v4
   # - KN2045plus_EasyRide

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -68,6 +68,15 @@ CurrentPolicies:
             2035: 40
             2040: 80
             2045: 125
+        electricity_gross_import:
+        # 2022: 54 TWh importiert
+          DE:
+            2020: 50
+            2025: 50
+            2030: 50
+            2035: 75
+            2040: 100
+            2045: 150
         electrolysis:
         # boundary condition lower?
           DE:
@@ -82,7 +91,7 @@ CurrentPolicies:
           DE:
             2020: 0
             2025: 0
-            2030: 10
+            2030: 0
             2035: 105
             2040: 200
             2045: 300
@@ -90,8 +99,8 @@ CurrentPolicies:
         # boundary condition lower?
           DE:
             2020: 0
-            2025: 5
-            2030: 15
+            2025: 0
+            2030: 5
             2035: 115
             2040: 220
             2045: 325
@@ -104,6 +113,14 @@ CurrentPolicies:
             2035: 0
             2040: 0
             2045: 0
+      limits_power_max: # in GW
+        DE:
+          2020: 15
+          2025: 15
+          2030: 15
+          2035: 20
+          2040: 25
+          2045: 30
 
   industry:
     steam_biomass_fraction: 0.4

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -72,11 +72,11 @@ CurrentPolicies:
         # 2022: 54 TWh importiert
           DE:
             2020: 50
-            2025: 50
-            2030: 50
-            2035: 75
-            2040: 100
-            2045: 150
+            2025: 70
+            2030: 100
+            2035: 150
+            2040: 200
+            2045: 250
         electrolysis:
         # boundary condition lower?
           DE:

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -334,9 +334,13 @@ def electricity_import_limits(n, investment_year, limits_volume_max):
     if limits_volume_max["electricity_gross_import"]:
         # add a gross volume constraint
         for ct in limits_volume_max["electricity_gross_import"]:
-            limit = limits_volume_max["electricity_gross_import"][ct][investment_year] * 1e6
+            limit = (
+                limits_volume_max["electricity_gross_import"][ct][investment_year] * 1e6
+            )
 
-            logger.info(f"limiting electricity gross imports in {ct} to {limit/1e6} TWh/a")
+            logger.info(
+                f"limiting electricity gross imports in {ct} to {limit/1e6} TWh/a"
+            )
 
             incoming_line = n.lines.index[
                 (n.lines.carrier == "AC")
@@ -351,10 +355,12 @@ def electricity_import_limits(n, investment_year, limits_volume_max):
             ]
 
             incoming_line_p = (
-                n.model["Line-s"].loc[:, incoming_line] * n.snapshot_weightings.generators
+                n.model["Line-s"].loc[:, incoming_line]
+                * n.snapshot_weightings.generators
             ).sum()
             incoming_link_p = (
-                n.model["Link-p"].loc[:, incoming_link] * n.snapshot_weightings.generators
+                n.model["Link-p"].loc[:, incoming_link]
+                * n.snapshot_weightings.generators
             ).sum()
 
             lhs = incoming_link_p + incoming_line_p

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -310,11 +310,13 @@ def electricity_import_limits(n, investment_year, limits_volume_max):
             n.model["Link-p"].loc[:, outgoing_link] * n.snapshot_weightings.generators
         ).sum()
 
-        lhs = (incoming_link_p - outgoing_link_p) + (incoming_line_p - outgoing_line_p)
+        # divide by 10 to avoid large bounds
+        lhs = (incoming_link_p - outgoing_link_p) + (incoming_line_p - outgoing_line_p) / 100
+        rhs = limit / 100
 
         cname = f"Electricity_import_limit-{ct}"
 
-        n.model.add_constraints(lhs <= limit, name=f"GlobalConstraint-{cname}")
+        n.model.add_constraints(lhs <= rhs, name=f"GlobalConstraint-{cname}")
 
         if cname in n.global_constraints.index:
             logger.warning(


### PR DESCRIPTION
In the `CurrentPolicies` scenario, the emissions in 2030 are too low compared to Remind and the [uba](https://www.umweltbundesamt.de/themen/klima-energie/klimaschutz-energiepolitik-in-deutschland/szenarien-fuer-die-klimaschutz-energiepolitik/integrierte-energie-treibhausgasprojektionen#2024).

In order to address this issue, the following boundary constraints are added:
- `config[solving][constraints][limits_volume_max][electricity_gross_import]` to restrict the gross import/export from/to Germany.
- import of hydrogen: restricted to 5 TWh since we assume a delay in production volume in Europe
- import of E-fuels: restricted to 0 TWh under the same assumption as the one for hydrogen

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [x] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
_will follow after cluster runs_
- [ ] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
