### PR TITLE
adjusting renewable max capacity to 'uba projektionsbericht'

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Changelog
+- Restricting the maximum capacity of CurrentPolicies and minus scenarios to the 'uba Projektionsbericht'
 - Restricting Fischer Tropsch capacity addition with config[solving][limit_DE_FT_cap]
 - Except for Current Policies force a minimum of 5 GW of electrolysis capacity in Germany
 - limit the import/export limit to/from Germany

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,10 +4,10 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241023ExporterUpdateGreenH2
+  prefix: 20241024_adjust_RE_constraints
   name:
-  # - CurrentPolicies
-  - KN2045_Bal_v4
+  - CurrentPolicies
+  # - KN2045_Bal_v4
   # - KN2045_Elec_v4
   # - KN2045_H2_v4
   # - KN2045plus_EasyRide
@@ -440,7 +440,7 @@ solving:
           DE:
             2020: 7.8
             2025: 11.3
-            2030: 30.4
+            2030: 31.3 # uba Projektionsbericht
             2035: 70
             2040: 70
             2045: 70

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -54,10 +54,10 @@ CurrentPolicies:
         Generator:
           onwind:
             DE:
-              2030: 115 # not better than targets
+              2030: 94.5 # uba Projektionsbericht
           solar:
             DE:
-              2030: 215
+              2030: 215 # uba Projektionsbericht
       limits_volume_max:
         # constrain electricity import in TWh
         electricity_import:
@@ -575,11 +575,10 @@ KN2045minus_WorstCase:
         Generator:
           onwind:
             DE:
-              2030: 115 # not better than targets
-
+              2030: 94.5 # uba Projektionsbericht
           solar:
             DE:
-              2030: 215
+              2030: 215 # uba Projektionsbericht
   industry:
     steam_biomass_fraction: 0.4
     steam_hydrogen_fraction: 0.3
@@ -685,10 +684,10 @@ KN2045minus_SupplyFocus:
         Generator:
           onwind:
             DE:
-              2030: 115 # not better than targets
+              2030: 94.5 # uba Projektionsbericht
           solar:
             DE:
-              2030: 215
+              2030: 215 # uba Projektionsbericht
   industry:
     steam_biomass_fraction: 0.4
     steam_hydrogen_fraction: 0.3


### PR DESCRIPTION
Adjusting the maximum capacity for the `CurrentPolicies` and `minus` scenarios following the [uba Projektionsbericht](https://www.umweltbundesamt.de/sites/default/files/medien/11850/publikationen/projektionen_technischer_anhang_0.pdf) Table 8:
Projected capacities 2030:
- solar: 215 GW
- onwind: 94.5 GW
- offwind: 31.3 GW

Since so far the maximum capacity of offshore wind was smaller than the report, it is also adjusted for the rest of the scenarios, hence in the `config.yaml`.

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
_not applicable_
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
_not applicable_
- [x] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
