### PR TITLE
increase NEP cost assumptions again

### DIFF
--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -25,7 +25,7 @@ CurrentPolicies:
 
   costs:
     horizon: "mean"
-    NEP: 2021
+    NEP: 2023
     transmission: "underground" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
@@ -130,7 +130,7 @@ KN2045_Bal_v4:
 
   costs:
     horizon: "mean"
-    NEP: 2021
+    NEP: 2023
     transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
@@ -202,7 +202,7 @@ KN2045_Elec_v4:
 
   costs:
     horizon: "mean"
-    NEP: 2021
+    NEP: 2023
     transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
@@ -273,7 +273,7 @@ KN2045_H2_v4:
 
   costs:
     horizon: "mean"
-    NEP: 2021
+    NEP: 2023
     transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
@@ -347,7 +347,7 @@ KN2045plus_EasyRide:
 
   costs:
     horizon: "optimist"
-    NEP: 2021
+    NEP: 2023
     transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
@@ -417,7 +417,7 @@ KN2045plus_LowDemand:
 
   costs:
     horizon: "optimist"
-    NEP: 2021
+    NEP: 2023
     transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:

--- a/config/scenarios.public.yaml
+++ b/config/scenarios.public.yaml
@@ -12,7 +12,7 @@
 
   costs:
     horizon: "mean"
-    NEP: 2021
+    NEP: 2023
     transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
@@ -79,7 +79,7 @@
 
   costs:
     horizon: "mean"
-    NEP: 2021
+    NEP: 2023
     transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:
@@ -145,7 +145,7 @@
 
   costs:
     horizon: "mean"
-    NEP: 2021
+    NEP: 2023
     transmission: "overhead" # either overhead line ("overhead") or underground cable ("underground")
   solving:
     constraints:

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -3815,8 +3815,9 @@ def get_grid_investments(n, costs, region, length_factor=1.0):
         )
     ] *= 0.5
 
-    var["Investment|Energy Supply|Hydrogen|Transmission and Distribution"] = \
-    var["Investment|Energy Supply|Hydrogen|Transmission"] = h2_investments.sum() / 5
+    var["Investment|Energy Supply|Hydrogen|Transmission and Distribution"] = var[
+        "Investment|Energy Supply|Hydrogen|Transmission"
+    ] = (h2_investments.sum() / 5)
 
     # TODO add retrofitted costs!!
 
@@ -4705,34 +4706,33 @@ def get_data(
 
     # Renaming variables
 
-    var["Investment|Energy Supply|Electricity|Wind Onshore"] = (
-        var["Investment|Energy Supply|Electricity|Wind|Onshore"] 
-    )
+    var["Investment|Energy Supply|Electricity|Wind Onshore"] = var[
+        "Investment|Energy Supply|Electricity|Wind|Onshore"
+    ]
 
-    var["Investment|Energy Supply|Electricity|Wind Offshore"] = (
-        var["Investment|Energy Supply|Electricity|Wind|Offshore"]
-    )
-    
-    var["Investment|Energy Supply|Electricity|Electricity Storage"] = (
-        var["Investment|Energy Supply|Electricity|Storage Reservoir"]
-    )
+    var["Investment|Energy Supply|Electricity|Wind Offshore"] = var[
+        "Investment|Energy Supply|Electricity|Wind|Offshore"
+    ]
 
-    var["Investment|Energy Supply|Heat|Heatpump"] = (
-        var["Investment|Energy Supply|Heat|Heat pump"]
-    )
+    var["Investment|Energy Supply|Electricity|Electricity Storage"] = var[
+        "Investment|Energy Supply|Electricity|Storage Reservoir"
+    ]
 
-    var["Investment|Energy Supply|Hydrogen|Storage"] = (
-        var["Investment|Energy Supply|Hydrogen|Reservoir"]
-    ) 
+    var["Investment|Energy Supply|Heat|Heatpump"] = var[
+        "Investment|Energy Supply|Heat|Heat pump"
+    ]
 
-    var["Investment|Energy Supply|Hydrogen|Electrolysis"] = (
-        var["Investment|Energy Supply|Hydrogen|Electricity"]
-    )
+    var["Investment|Energy Supply|Hydrogen|Storage"] = var[
+        "Investment|Energy Supply|Hydrogen|Reservoir"
+    ]
 
-    var["Investment|Energy Supply|Hydrogen|Fossil"] = (
-        var["Investment|Energy Supply|Hydrogen|Gas"]
-    )
+    var["Investment|Energy Supply|Hydrogen|Electrolysis"] = var[
+        "Investment|Energy Supply|Hydrogen|Electricity"
+    ]
 
+    var["Investment|Energy Supply|Hydrogen|Fossil"] = var[
+        "Investment|Energy Supply|Hydrogen|Gas"
+    ]
 
     data = []
     for v in var.index:


### PR DESCRIPTION
Since we are now seeing quite substantial network expansion in terms of Trassenlänge (exogen + endogen), we may aswell switch back to the NEP 23 costs. At least we need to do sensitivity studies. 

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
