### PR TITLE
Adding capacity limit for MeOH and FT

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Changelog
+- Restricting the capacity of Fischer-Tropsch and Methanol production in Germany
 - Restricting the maximum capacity of CurrentPolicies and minus scenarios to the 'uba Projektionsbericht'
 - Restricting Fischer Tropsch capacity addition with config[solving][limit_DE_FT_cap]
 - Except for Current Policies force a minimum of 5 GW of electrolysis capacity in Germany

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -462,6 +462,19 @@ solving:
             2035: 20000
             2040: 50000
             2045: 80000
+      Link:
+        methanolisation:
+          DE:
+            2030: 5
+            2035: 5
+            2040: 5
+            2045: 5
+        Fischer-Tropsch:
+          DE:
+            2030: 2
+            2035: 2
+            2040: 2
+            2045: 2
     limits_capacity_min:
       Generator:
         onwind:
@@ -485,19 +498,6 @@ solving:
             2035: 101
             2040: 101
             2045: 101
-      Link:
-        methanolisation:
-          DE:
-            2030: 5
-            2035: 5
-            2040: 5
-            2045: 5
-        Fischer-Tropsch:
-          DE:
-            2030: 2
-            2035: 2
-            2040: 2
-            2045: 2
 
   # For reference, this are the values specified in the laws
   # limits_capacity_min:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241030_limit_FT
+  prefix: 20241105_FT_MeOH_cap_limit
 
   name:
   # - CurrentPolicies
@@ -485,6 +485,20 @@ solving:
             2035: 101
             2040: 101
             2045: 101
+      Link:
+        methanolisation:
+          DE:
+            2030: 5
+            2035: 5
+            2040: 5
+            2045: 5
+        Fischer-Tropsch:
+          DE:
+            2030: 2
+            2035: 2
+            2040: 2
+            2045: 2
+
   # For reference, this are the values specified in the laws
   # limits_capacity_min:
   #     Generator:
@@ -549,14 +563,6 @@ solving:
           2035: 115
           2040: 220
           2045: 325
-      FT_production:
-        DE:
-          2020: 15
-          2025: 15
-          2030: 15
-          2035: 15
-          2040: 15
-          2045: 15
     limits_volume_min:
       electrolysis:
         DE:

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -675,6 +675,7 @@ def adapt_nuclear_output(n):
         carrier_attribute="",
     )
 
+
 def additional_functionality(n, snapshots, snakemake):
 
     logger.info("Adding Ariadne-specific functionality")

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -241,7 +241,9 @@ def h2_production_limits(n, investment_year, limits_volume_min, limits_volume_ma
         efficiency = n.links.loc[production, "efficiency"]
 
         lhs = (
-            n.model["Link-p"].loc[:, production] * n.snapshot_weightings.generators * efficiency
+            n.model["Link-p"].loc[:, production]
+            * n.snapshot_weightings.generators
+            * efficiency
         ).sum()
 
         cname_upper = f"H2_production_limit_upper-{ct}"

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -41,14 +41,20 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                 extendable_index = c.df.index[
                     valid_components & c.df[attr + "_nom_extendable"]
                 ]
-                efficiency = (
+                # TODO: I need two efficiency factors here:
+                existing_efficiency = (
                     c.df.loc[existing_index, "efficiency"]
+                    if (c.name == "Link") and (carrier != "H2 Electrolysis")
+                    else 1
+                )
+                extendable_efficiency = (
+                    c.df.loc[extendable_index, "efficiency"]
                     if (c.name == "Link") and (carrier != "H2 Electrolysis")
                     else 1
                 )
 
                 existing_capacity = (
-                    c.df.loc[existing_index, attr + "_nom"] * efficiency
+                    c.df.loc[existing_index, attr + "_nom"] * existing_efficiency
                 ).sum()
 
                 logger.info(
@@ -57,7 +63,7 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
 
                 nom = n.model[c.name + "-" + attr + "_nom"].loc[extendable_index]
 
-                lhs = (nom * efficiency).sum()
+                lhs = (nom * extendable_efficiency).sum()
 
                 cname = f"capacity_{sense}-{ct}-{c.name}-{carrier.replace(' ','-')}"
 

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -238,10 +238,11 @@ def h2_production_limits(n, investment_year, limits_volume_min, limits_volume_ma
         production = n.links[
             (n.links.carrier == "H2 Electrolysis") & (n.links.bus0.str.contains(ct))
         ].index
+        efficiency = n.links.loc[production, "efficiency"].mean()
 
         lhs = (
             n.model["Link-p"].loc[:, production] * n.snapshot_weightings.generators
-        ).sum()
+        ).sum() / efficiency
 
         cname_upper = f"H2_production_limit_upper-{ct}"
         cname_lower = f"H2_production_limit_lower-{ct}"

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -41,11 +41,7 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                 extendable_index = c.df.index[
                     valid_components & c.df[attr + "_nom_extendable"]
                 ]
-                efficiency = (
-                    c.df.loc[existing_index, "efficiency"].mean()
-                    if (c.name == "Link") and (carrier is not "Electrolysis")
-                    else 1
-                )
+                efficiency = c.df.loc[existing_index, "efficiency"].mean() if (c.name == "Link") and (carrier != "electrolysis") else 1
 
                 existing_capacity = (
                     c.df.loc[existing_index, attr + "_nom"].sum() / efficiency

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -41,9 +41,15 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                 extendable_index = c.df.index[
                     valid_components & c.df[attr + "_nom_extendable"]
                 ]
-                efficiency = c.df.loc[existing_index, "efficiency"].mean() if (c.name == "Link") and (carrier is not "Electrolysis") else 1
+                efficiency = (
+                    c.df.loc[existing_index, "efficiency"].mean()
+                    if (c.name == "Link") and (carrier is not "Electrolysis")
+                    else 1
+                )
 
-                existing_capacity = c.df.loc[existing_index, attr + "_nom"].sum() / efficiency
+                existing_capacity = (
+                    c.df.loc[existing_index, attr + "_nom"].sum() / efficiency
+                )
 
                 logger.info(
                     f"Existing {c.name} {carrier} capacity in {ct}: {existing_capacity} {units}"

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -41,7 +41,11 @@ def add_capacity_limits(n, investment_year, limits_capacity, sense="maximum"):
                 extendable_index = c.df.index[
                     valid_components & c.df[attr + "_nom_extendable"]
                 ]
-                efficiency = c.df.loc[existing_index, "efficiency"].mean() if (c.name == "Link") and (carrier != "electrolysis") else 1
+                efficiency = (
+                    c.df.loc[existing_index, "efficiency"].mean()
+                    if (c.name == "Link") and (carrier != "electrolysis")
+                    else 1
+                )
 
                 existing_capacity = (
                     c.df.loc[existing_index, attr + "_nom"].sum() / efficiency

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -813,7 +813,9 @@ def _get_capacities(n, region, cap_func, cap_string="Capacity|"):
         + var[cap_string + "Hydrogen|Gas|w/o CCS"]
     )
 
-    var[cap_string + "Hydrogen|Electricity"] = abs(capacities_electricity.get("H2 Electrolysis", 0))
+    var[cap_string + "Hydrogen|Electricity"] = abs(
+        capacities_electricity.get("H2 Electrolysis", 0)
+    )
 
     var[cap_string + "Hydrogen"] = (
         capacities_h2.get("H2 Electrolysis", 0) + var[cap_string + "Hydrogen|Gas"]

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -988,7 +988,7 @@ def get_primary_energy(n, region):
     assert isclose(
         var["Primary Energy|Oil"],
         n.statistics.withdrawal(bus_carrier="oil primary", **kwargs)
-        .get(("Link", "DE oil refining"))
+        .get(("Link", "DE oil refining"), pd.Series(0))
         .multiply(MWh2PJ)
         .item(),
     )
@@ -1041,7 +1041,7 @@ def get_primary_energy(n, region):
     assert isclose(
         var["Primary Energy|Gas"],
         n.statistics.withdrawal(bus_carrier="gas primary", **kwargs)
-        .get(("Link", "DE gas compressing"))
+        .get(("Link", "DE gas compressing"), pd.Series(0))
         .multiply(MWh2PJ)
         .item(),
     )

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -813,10 +813,10 @@ def _get_capacities(n, region, cap_func, cap_string="Capacity|"):
         + var[cap_string + "Hydrogen|Gas|w/o CCS"]
     )
 
-    var[cap_string + "Hydrogen|Electricity"] = capacities_h2.get("H2 Electrolysis", 0)
+    var[cap_string + "Hydrogen|Electricity"] = abs(capacities_electricity.get("H2 Electrolysis", 0))
 
     var[cap_string + "Hydrogen"] = (
-        var[cap_string + "Hydrogen|Electricity"] + var[cap_string + "Hydrogen|Gas"]
+        capacities_h2.get("H2 Electrolysis", 0) + var[cap_string + "Hydrogen|Gas"]
     )
 
     # This check requires further changes to n.statistics

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -4577,7 +4577,9 @@ def hack_DC_projects(n, n_start, model_year, snakemake, costs):
     n.links.loc[future_projects, "p_nom"] = 0
     n.links.loc[future_projects, "p_nom_min"] = 0
 
-    if (snakemake.params.NEP_year == 2021) or (snakemake.params.NEP_transmission == "overhead"):
+    if (snakemake.params.NEP_year == 2021) or (
+        snakemake.params.NEP_transmission == "overhead"
+    ):
         logger.warning("Switching DC projects to NEP23 costs post-optimization")
         n.links.loc[current_projects, "overnight_cost"] = (
             n.links.loc[current_projects, "length"]


### PR DESCRIPTION
Closing https://github.com/PyPSA/pypsa-ariadne/issues/271 and https://github.com/PyPSA/pypsa-ariadne/issues/270
Adding a capacity limit of 2GW and 5GW for Fischer-Tropsch and Methanolisation in Germany respectively.
Furthermore, the production volume limit for hydrogen within Germany is now calibrated towards MWh_H2 and not MWh_electricity.

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
_not applicable_
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
_not applicable_
- [x] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
