### PR TITLE
improving NEP plots

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -473,7 +473,6 @@ rule download_ariadne_template:
 
 rule export_ariadne_variables:
     params:
-        length_factor=config_provider("lines", "length_factor"),
         planning_horizons=config_provider("scenario", "planning_horizons"),
         hours=config_provider("clustering", "temporal", "resolution_sector"),
         costs=config_provider("costs"),
@@ -565,6 +564,8 @@ rule plot_ariadne_variables:
         trade=RESULTS + "ariadne/trade.png",
         NEP_plot=RESULTS + "ariadne/NEP_plot.png",
         NEP_Trassen_plot=RESULTS + "ariadne/NEP_Trassen_plot.png",
+        transmission_investment_csv=RESULTS + "ariadne/transmission_investment.csv",
+        trassenlaenge_csv=RESULTS + "ariadne/trassenlaenge.csv",
     log:
         RESULTS + "logs/plot_ariadne_variables.log",
     script:

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -4928,11 +4928,11 @@ if __name__ == "__main__":
     # In this hacky part of the code we assure that the investments for the AC projects, match those of the NEP-AC-Startnetz
     # Thus the variable 'Investment|Energy Supply|Electricity|Transmission|AC' is equal to the sum of exogeneous AC projects, endogenous AC expansion and Übernahme of NEP costs (mainly Systemdienstleistungen (Reactive Power Compensation) and lines that are below our spatial resolution)
     ac_startnetz = 14.5 / 5  # billion EUR
-    
+
     ac_projects_invest = df.query(
         "Variable == 'Investment|Energy Supply|Electricity|Transmission|AC|NEP|Onshore'"
-        )[planning_horizons].values.sum()
-    
+    )[planning_horizons].values.sum()
+
     df.loc[
         df.query(
             "Variable == 'Investment|Energy Supply|Electricity|Transmission|AC|Übernahme|Startnetz Delta'"

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -4927,16 +4927,12 @@ if __name__ == "__main__":
     print("Gleichschaltung of AC-Startnetz with investments for AC projects")
     # In this hacky part of the code we assure that the investments for the AC projects, match those of the NEP-AC-Startnetz
     # Thus the variable 'Investment|Energy Supply|Electricity|Transmission|AC' is equal to the sum of exogeneous AC projects, endogenous AC expansion and Übernahme of NEP costs (mainly Systemdienstleistungen (Reactive Power Compensation) and lines that are below our spatial resolution)
-    # TODO Treat endogeneous expansion of AC projects separately??
     ac_startnetz = 14.5 / 5  # billion EUR
-    ac_projects_invest = (
-        df.query(
-            "Variable == 'Investment|Energy Supply|Electricity|Transmission|AC|NEP'"
+    
+    ac_projects_invest = df.query(
+        "Variable == 'Investment|Energy Supply|Electricity|Transmission|AC|NEP|Onshore'"
         )[planning_horizons].values.sum()
-        - df.query("Variable.str.endswith('Reactive Power Compensation')")[
-            planning_horizons
-        ].values.sum()
-    )
+    
     df.loc[
         df.query(
             "Variable == 'Investment|Energy Supply|Electricity|Transmission|AC|Übernahme|Startnetz Delta'"

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -317,7 +317,6 @@ def get_investments(n, costs, region):
         n,
         costs,
         region,
-        length_factor=snakemake.params.length_factor,
     )
 
     var["Investment|Energy Supply|Electricity"] += grid_var[
@@ -3657,9 +3656,8 @@ def get_discretized_value(value, disc_int, build_threshold=0.3):
     return base + discrete
 
 
-def get_grid_investments(n, costs, region, length_factor=1.0):
+def get_grid_investments(n, costs, region):
     # TODO gap between years should be read from config
-    # TODO Discretization units should be read from config
     var = pd.Series()
 
     offwind = n.generators.filter(like="offwind", axis=0).filter(like="DE", axis=0)
@@ -3670,12 +3668,12 @@ def get_grid_investments(n, costs, region, length_factor=1.0):
     offwind_connection_dc = offwind_connection_overnight_cost.filter(regex="dc|float")
     var_name = "Investment|Energy Supply|Electricity|Transmission|"
     var[var_name + "AC|Offshore"] = offwind_connection_ac.sum() / 5
-    var[var_name + "AC|Offshore|NEP"] = (
+    var[var_name + "AC|NEP|Offshore"] = (
         offwind_connection_ac.filter(regex="25|30").sum() / 5
     )
 
     var[var_name + "DC|Offshore"] = offwind_connection_dc.sum() / 5
-    var[var_name + "DC|Offshore|NEP"] = (
+    var[var_name + "DC|NEP|Offshore"] = (
         offwind_connection_dc.filter(regex="25|30").sum() / 5
     )
 
@@ -3684,8 +3682,9 @@ def get_grid_investments(n, costs, region, length_factor=1.0):
         & (n.links.bus0 + n.links.bus1).str.contains(region)
         & ~n.links.reversed
     ]
+    current_year = n.generators.build_year.max()
     nep_dc = dc_links.query(
-        "index.str.startswith('DC') or index=='TYNDP2020_1' or index=='TYNDP2020_2' or index=='TYNDP2020_23'"
+        "(index.str.startswith('DC') or index.str.startswith('TYNDP')) and build_year > 2025 and (@current_year - 5 < build_year <= @current_year)"
     ).index
     dc_expansion = dc_links.p_nom_opt - dc_links.p_nom_min
 
@@ -3696,7 +3695,7 @@ def get_grid_investments(n, costs, region, length_factor=1.0):
     ] *= 0.5
 
     ac_lines = n.lines[(n.lines.bus0 + n.lines.bus1).str.contains(region)]
-    nep_ac = ac_lines.query("build_year > 2000").index
+    nep_ac = ac_lines.query("(build_year > 2025) and (@current_year - 5 < build_year <= @current_year)").index
     # Assuming the lines are already post-discretized
     ac_expansion = ac_lines.s_nom_opt - ac_lines.s_nom_min
 
@@ -3718,16 +3717,17 @@ def get_grid_investments(n, costs, region, length_factor=1.0):
         2040: 10,
         2045: 1.5,
     }
-    var[var_name + "AC|Reactive Power Compensation"] = (
+    var[var_name + "AC|Übernahme|Reactive Power Compensation"] = (
         reactive_power_compensation.get(year, 0) / 5
     )
+    var[var_name + "AC|Übernahme|Startnetz Delta"] = 0
 
     var[var_name + "AC|Onshore"] = ac_investments.sum() / 5
-    var[var_name + "AC|Onshore|NEP"] = ac_investments[nep_ac].sum() / 5
+    var[var_name + "AC|NEP|Onshore"] = ac_investments[nep_ac].sum() / 5
     var[var_name + "DC|Onshore"] = dc_investments.sum() / 5
-    var[var_name + "DC|Onshore|NEP"] = dc_investments[nep_dc].sum() / 5
+    var[var_name + "DC|NEP|Onshore"] = dc_investments[nep_dc].sum() / 5
 
-    for key in ["Onshore", "Onshore|NEP", "Offshore", "Offshore|NEP"]:
+    for key in ["Onshore", "NEP|Onshore", "Offshore", "NEP|Offshore"]:
         var[var_name + f"{key}"] = (
             var[var_name + f"AC|{key}"] + var[var_name + f"DC|{key}"]
         )
@@ -3735,16 +3735,16 @@ def get_grid_investments(n, costs, region, length_factor=1.0):
     var[var_name + "AC"] = (
         var[var_name + "AC|Onshore"]
         + var[var_name + "AC|Offshore"]
-        + var[var_name + "AC|Reactive Power Compensation"]
+        + var[var_name + "AC|Übernahme|Reactive Power Compensation"]
     )
     var[var_name + "AC|NEP"] = (
-        var[var_name + "AC|Onshore|NEP"]
-        + var[var_name + "AC|Offshore|NEP"]
-        + var[var_name + "AC|Reactive Power Compensation"]
+        var[var_name + "AC|NEP|Onshore"]
+        + var[var_name + "AC|NEP|Offshore"]
+        + var[var_name + "AC|Übernahme|Reactive Power Compensation"]
     )
     var[var_name + "DC"] = var[var_name + "DC|Onshore"] + var[var_name + "DC|Offshore"]
     var[var_name + "DC|NEP"] = (
-        var[var_name + "DC|Onshore|NEP"] + var[var_name + "DC|Offshore|NEP"]
+        var[var_name + "DC|NEP|Onshore"] + var[var_name + "DC|NEP|Offshore"]
     )
     var["Investment|Energy Supply|Electricity|Transmission"] = (
         var[var_name + "AC"] + var[var_name + "DC"]
@@ -4440,16 +4440,19 @@ def get_grid_capacity(n, region, year):
     )
     var["Length Additions|Electricity|Transmission|DC"] = (
         dc_links.eval("p_nom_opt - p_nom_min")
-        .floordiv(995)
-        .div(2)
+        .floordiv(
+            snakemake.params.post_discretization["link_unit_size"]["DC"]
+            - 5 # To account for numerical errors subtract a small capacity
+        )
+        .multiply(snakemake.params.post_discretization["link_unit_size"]["DC"] / 2000)
         .multiply(dc_links.length)
         .sum()
     )
     var["Length Additions|Electricity|Transmission|DC|NEP"] = (
         dc_links.loc[nep_dc]
         .eval("p_nom_opt - p_nom_min")
-        .floordiv(995)
-        .div(2)
+        .floordiv(snakemake.params.post_discretization["link_unit_size"]["DC"] - 5)
+        .multiply(snakemake.params.post_discretization["link_unit_size"]["DC"] / 2000)
         .multiply(dc_links.length)
         .sum()
     )
@@ -4467,18 +4470,16 @@ def get_grid_capacity(n, region, year):
     )
     var["Length Additions|Electricity|Transmission|AC"] = (
         ac_lines.eval("s_nom_opt - s_nom_min")
-        .floordiv(845)
-        .div(2)
-        .div(3)  # Steps of half a `line_unit`, 3 lines are a Trasse
+        .floordiv(snakemake.params.post_discretization["line_unit_size"] - 5)
+        .mul(snakemake.params.post_discretization["line_unit_size"] / (2*2633)) # Trassen size is 2 * 2633, we allow "fractional Trassen" to account for different line types
         .multiply(ac_lines.length)
         .sum()
     )
     var["Length Additions|Electricity|Transmission|AC|NEP"] = (
         ac_lines.loc[nep_ac]
         .eval("s_nom_opt - s_nom_min")
-        .floordiv(845)
-        .div(2)
-        .div(3)
+        .floordiv(snakemake.params.post_discretization["line_unit_size"] - 5)
+        .mul(snakemake.params.post_discretization["line_unit_size"] / (2*2633))
         .multiply(ac_lines.length)
         .sum()
     )
@@ -4917,6 +4918,32 @@ if __name__ == "__main__":
         yearly_dfs,
     )
 
+    print("Gleichschaltung of AC-Startnetz with investments for AC projects")
+    # In this hacky part of the code we assure that the investments for the AC projects, match those of the NEP-AC-Startnetz
+    # Thus the variable 'Investment|Energy Supply|Electricity|Transmission|AC' is equal to the sum of exogeneous AC projects, endogenous AC expansion and Übernahme of NEP costs (mainly Systemdienstleistungen (Reactive Power Compensation) and lines that are below our spatial resolution)
+    # TODO Treat endogeneous expansion of AC projects separately??
+    ac_startnetz = 14.5 / 5 # billion EUR
+    ac_projects_invest = (
+        df.query(
+            "Variable == 'Investment|Energy Supply|Electricity|Transmission|AC|NEP'")[planning_horizons].values.sum()
+        - df.query(
+            "Variable.str.endswith('Reactive Power Compensation')")[planning_horizons].values.sum()
+    )
+    df.loc[
+        df.query("Variable == 'Investment|Energy Supply|Electricity|Transmission|AC|Übernahme|Startnetz Delta'").index,
+        [2025, 2030, 2035, 2040]
+    ] += (ac_startnetz - ac_projects_invest) / 4
+
+    df.loc[
+        df.query("Variable == 'Investment|Energy Supply|Electricity|Transmission|AC|NEP'").index,
+        [2025, 2030, 2035, 2040]
+    ] += (ac_startnetz - ac_projects_invest) / 4
+
+    df.loc[
+        df.query("Variable == 'Investment|Energy Supply|Electricity|Transmission|AC'").index,
+        [2025, 2030, 2035, 2040]
+    ] += (ac_startnetz - ac_projects_invest) / 4
+
     print("Assigning mean investments of year and year + 5 to year.")
     investment_rows = df.loc[df["Variable"].str.contains("Investment")]
     average_investments = (
@@ -4944,7 +4971,7 @@ if __name__ == "__main__":
         *df.loc[df["Unit"] == "NA"]["Variable"],
         sep="\n",
     )
-    df.drop(df.loc[df["Unit"] == "NA"].index, inplace=True)
+    ariadne_df = df.drop(df.loc[df["Unit"] == "NA"].index)
 
     meta = pd.Series(
         {
@@ -4957,5 +4984,5 @@ if __name__ == "__main__":
     )
 
     with pd.ExcelWriter(snakemake.output.exported_variables) as writer:
-        df.round(5).to_excel(writer, sheet_name="data", index=False)
+        ariadne_df.round(5).to_excel(writer, sheet_name="data", index=False)
         meta.to_frame().T.to_excel(writer, sheet_name="meta", index=False)

--- a/workflow/scripts/plot_ariadne_variables.py
+++ b/workflow/scripts/plot_ariadne_variables.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 
 
-def plot_NEP_Trassen(df, savepath=None):
+def plot_NEP_Trassen(df, savepath=None, gleichschaltung=True):
 
     NEP_Trassen = {
         "NEP-DC": {
@@ -29,7 +29,7 @@ def plot_NEP_Trassen(df, savepath=None):
     }
 
     data = {
-        "Category": ["DC", "AC"],
+        "Kategorie": ["DC", "AC"],
         "Startnetz": [
             NEP_Trassen["NEP-DC"]["Startnetz"],
             NEP_Trassen["NEP-AC"]["Startnetz"],
@@ -42,10 +42,15 @@ def plot_NEP_Trassen(df, savepath=None):
             NEP_Trassen["PyPSA-DC"]["exogen"],
             NEP_Trassen["PyPSA-AC"]["exogen"],
         ],
+        "Übernahme": [
+            0,
+            NEP_Trassen["NEP-AC"]["Startnetz"] - NEP_Trassen["PyPSA-AC"]["exogen"],
+        ],
         "endogen": [
             NEP_Trassen["PyPSA-DC"]["endogen"],
             NEP_Trassen["PyPSA-AC"]["endogen"],
         ],
+
     }
 
     plotframe = pd.DataFrame(data)
@@ -65,118 +70,95 @@ def plot_NEP_Trassen(df, savepath=None):
         label="Zubaunetz",
     )
     plt.bar(indices + bar_width, plotframe["exogen"], bar_width, label="exogen")
+    bottom = plotframe["exogen"].copy()
+    if gleichschaltung:
+        plt.bar(
+            indices + bar_width,
+            plotframe["Übernahme"],
+            bar_width,
+            bottom=plotframe["exogen"],
+            label="Übernahme",
+            color="darkgreen",
+        )
+        bottom += plotframe["Übernahme"]
     plt.bar(
         indices + bar_width,
         plotframe["endogen"],
         bar_width,
-        bottom=plotframe["exogen"],
+        bottom=bottom,
         label="endogen",
     )
 
-    plt.xlabel("Category")
+    plt.xlabel("Kategorie")
     plt.ylabel("km")
-    plt.title("Trassenlänge Onshore Transmission Grid")
+    plt.title("Trassenlänge Übertragungsnetz Onshore")
 
     # Adjust the x-ticks to be between the two bars
-    plt.xticks(indices + bar_width / 2, plotframe["Category"])
+    plt.xticks(indices + bar_width / 2, plotframe["Kategorie"])
     plt.legend()
     if savepath:
         plt.savefig(savepath, bbox_inches="tight")
     else:
         plt.show()
 
+    plotframe["NEP-Total"] = plotframe["Startnetz"] + plotframe["Zubaunetz"]
+    plotframe["PyPSA-Total"] = plotframe["exogen"] + plotframe["endogen"] + plotframe["Übernahme"]
+    plotframe.to_csv(snakemake.output.trassenlaenge_csv)
 
-def plot_NEP(df, savepath=None):
+def plot_NEP(df, savepath=None, gleichschaltung=True):
     key = "Investment|Energy Supply|Electricity|Transmission|"
 
-    NEP_investment = {
-        "NEP-Offshore": {"Startnetz": 12.4, "Zubaunetz": 145.1},
-        "PyPSA-Offshore": {
-            "exogen": df.loc[key + "Offshore|NEP"].values.sum() * 5,
-            "endogen": (
-                df.loc[key + "Offshore"].values - df.loc[key + "Offshore|NEP"].values
-            ).sum()
-            * 5,
-        },
-        "NEP-DC": {"Startnetz": 26, "Zubaunetz": 46.2},
-        "PyPSA-DC": {
-            "exogen": df.loc[key + "DC|Onshore|NEP"].values.sum() * 5,
-            "endogen": (
-                df.loc[key + "DC|Onshore"].values
-                - df.loc[key + "DC|Onshore|NEP"].values
-            ).sum()
-            * 5,
-        },
-        "NEP-AC": {"Startnetz": 14.5, "Zubaunetz": 30.5},
-        "PyPSA-AC": {
-            "exogen": df.loc[key + "AC|Onshore|NEP"].values.sum() * 5,
-            "endogen": (
-                df.loc[key + "AC|Onshore"].values
-                - df.loc[key + "AC|Onshore|NEP"].values
-            ).sum()
-            * 5,
-        },
-        "NEP-Q": {"Startnetz": 9.4, "Zubaunetz": 29.5},
-        "PyPSA-Q": {
-            "exogen": df.loc[key + "AC|Reactive Power Compensation"].values.sum() * 5,
-        },
-    }
-    NEP_investment = pd.DataFrame(NEP_investment).T
-    NEP_investment.loc["NEP-Onshore", "Startnetz"] = (
-        NEP_investment.loc["NEP-DC", "Startnetz"]
-        + NEP_investment.loc["NEP-AC", "Startnetz"]
-        + NEP_investment.loc["NEP-Q", "Startnetz"]
-    )
-    NEP_investment.loc["NEP-Onshore", "Zubaunetz"] = (
-        NEP_investment.loc["NEP-DC", "Zubaunetz"]
-        + NEP_investment.loc["NEP-AC", "Zubaunetz"]
-        + NEP_investment.loc["NEP-Q", "Zubaunetz"]
-    )
-    NEP_investment.loc["PyPSA-Onshore", "exogen"] = (
-        NEP_investment.loc["PyPSA-DC", "exogen"]
-        + NEP_investment.loc["PyPSA-AC", "exogen"]
-        + NEP_investment.loc["PyPSA-Q", "exogen"]
-    )
-    NEP_investment.loc["PyPSA-Onshore", "endogen"] = (
-        NEP_investment.loc["PyPSA-DC", "endogen"]
-        + NEP_investment.loc["PyPSA-AC", "endogen"]
-    )
-
-    # Create a DataFrame in the format ChatGPT suggested
     data = {
-        "Category": ["DC", "AC", "Q", "Onshore", "Offshore"],
+        "Kategorie": ["DC", "AC", "System-\ndienstleistungen", "Onshore", "Offshore"],
         "Startnetz": [
-            NEP_investment.loc["NEP-DC", "Startnetz"],
-            NEP_investment.loc["NEP-AC", "Startnetz"],
-            NEP_investment.loc["NEP-Q", "Startnetz"],
-            NEP_investment.loc["NEP-Onshore", "Startnetz"],
-            NEP_investment.loc["NEP-Offshore", "Startnetz"],
+            26,
+            14.5,
+            9.4,
+            None,
+            12.4,
         ],
         "Zubaunetz": [
-            NEP_investment.loc["NEP-DC", "Zubaunetz"],
-            NEP_investment.loc["NEP-AC", "Zubaunetz"],
-            NEP_investment.loc["NEP-Q", "Zubaunetz"],
-            NEP_investment.loc["NEP-Onshore", "Zubaunetz"],
-            NEP_investment.loc["NEP-Offshore", "Zubaunetz"],
+            46.2,
+            30.5,
+            29.5,
+            None,
+            145.1,
         ],
         "exogen": [
-            NEP_investment.loc["PyPSA-DC", "exogen"],
-            NEP_investment.loc["PyPSA-AC", "exogen"],
-            NEP_investment.loc["PyPSA-Q", "exogen"],
-            NEP_investment.loc["PyPSA-Onshore", "exogen"],
-            NEP_investment.loc["PyPSA-Offshore", "exogen"],
+            df.loc[key + "DC|NEP|Onshore"].values.sum() * 5,
+            df.loc[key + "AC|NEP|Onshore"].values.sum() * 5,
+            0, # see "Übernahme"
+            None,
+            df.loc[key + "NEP|Offshore"].values.sum() * 5,
         ],
         "endogen": [
-            NEP_investment.loc["PyPSA-DC", "endogen"],
-            NEP_investment.loc["PyPSA-AC", "endogen"],
+            (
+                df.loc[key + "DC|Onshore"].values
+                - df.loc[key + "DC|NEP|Onshore"].values
+            ).sum() * 5,
+            (
+                df.loc[key + "AC|Onshore"].values
+                - df.loc[key + "AC|NEP|Onshore"].values
+            ).sum() * 5,
             0,
-            NEP_investment.loc["PyPSA-Onshore", "endogen"],
-            NEP_investment.loc["PyPSA-Offshore", "endogen"],
+            None,
+            (
+                df.loc[key + "Offshore"].values 
+                - df.loc[key + "NEP|Offshore"].values
+            ).sum() * 5,
+        ],
+        "Übernahme": [
+            0,
+            df.loc[key + "AC|Übernahme|Startnetz Delta"].values.sum() * 5,
+            df.loc[key + "AC|Übernahme|Reactive Power Compensation"].values.sum() * 5,
+            None,
+            0,
         ],
     }
 
     plotframe = pd.DataFrame(data)
-
+    plotframe.set_index("Kategorie", inplace=True)
+    plotframe.loc["Onshore"] = plotframe.loc[["AC", "DC", "System-\ndienstleistungen"]].sum()
     # Define the width of the bars
     bar_width = 0.35
     indices = np.arange(len(plotframe))  # Bar positions
@@ -192,23 +174,59 @@ def plot_NEP(df, savepath=None):
         label="Zubaunetz",
     )
     plt.bar(indices + bar_width, plotframe["exogen"], bar_width, label="exogen")
+    bottom = plotframe["exogen"].copy()
+    if gleichschaltung:
+        plt.bar(
+            indices + bar_width,
+            plotframe["Übernahme"],
+            bar_width,
+            bottom=plotframe["exogen"],
+            label="Übernahme",
+            color="darkgreen",
+        )
+        bottom += plotframe["Übernahme"]
     plt.bar(
         indices + bar_width,
         plotframe["endogen"],
         bar_width,
-        bottom=plotframe["exogen"],
+        bottom=bottom,
         label="endogen",
     )
 
-    plt.xlabel("Category")
-    plt.ylabel("billion EUR")
-    plt.title("Investment in Transmission Grid")
+    plt.xlabel("Kategorie")
+    plt.ylabel("Billionen EUR")
+    plt.title("Investitionen ins Übertragungsnetz")
 
     # Adjust the x-ticks to be between the two bars
-    plt.xticks(indices + bar_width / 2, plotframe["Category"])
+    plt.xticks(indices + bar_width / 2, plotframe.index)
     plt.legend()
 
-    plt.savefig(savepath, bbox_inches="tight")
+
+
+
+    # Rename the category to remove the format string again
+    plotframe.rename(index={"System-\ndienstleistungen": "Systemdienstleistungen"}, inplace=True)
+    plotframe["NEP-Total"] = plotframe["Startnetz"] + plotframe["Zubaunetz"]
+    plotframe["PyPSA-Total"] = plotframe["exogen"] + plotframe["endogen"] + plotframe["Übernahme"]
+
+    # Add total costs annotations
+
+    plt.text(
+        1.05, 0.95, f"NEP: {round(plotframe.loc["Onshore","NEP-Total"] + plotframe.loc["Offshore","NEP-Total"],1)}", transform=plt.gca().transAxes,
+        fontsize=12, verticalalignment='top', bbox=dict(facecolor='white', alpha=0.5)
+    )
+    plt.text(
+        1.05, 0.85, f"PyPSA: {round(plotframe.loc["Onshore","PyPSA-Total"] + plotframe.loc["Offshore","PyPSA-Total"],1)}", transform=plt.gca().transAxes,
+        fontsize=12, verticalalignment='top', bbox=dict(facecolor='white', alpha=0.5)
+    )
+
+    
+    if savepath:
+        plt.savefig(savepath, bbox_inches="tight")
+    else:
+        plt.show()
+
+    plotframe.to_csv(snakemake.output.transmission_investment_csv)
 
 
 def secondary_energy_plot(ddf, name="Secondary Energy"):
@@ -769,7 +787,7 @@ if __name__ == "__main__":
         dfremind,
         title="Investment in Energy Supply",
         savepath=snakemake.output.investment_energy_supply,
-        unit="billion EUR",
+        unit="Billionen EUR",
         write_sum=True,
     )
 

--- a/workflow/scripts/plot_ariadne_variables.py
+++ b/workflow/scripts/plot_ariadne_variables.py
@@ -50,7 +50,6 @@ def plot_NEP_Trassen(df, savepath=None, gleichschaltung=True):
             NEP_Trassen["PyPSA-DC"]["endogen"],
             NEP_Trassen["PyPSA-AC"]["endogen"],
         ],
-
     }
 
     plotframe = pd.DataFrame(data)
@@ -102,8 +101,11 @@ def plot_NEP_Trassen(df, savepath=None, gleichschaltung=True):
         plt.show()
 
     plotframe["NEP-Total"] = plotframe["Startnetz"] + plotframe["Zubaunetz"]
-    plotframe["PyPSA-Total"] = plotframe["exogen"] + plotframe["endogen"] + plotframe["Übernahme"]
+    plotframe["PyPSA-Total"] = (
+        plotframe["exogen"] + plotframe["endogen"] + plotframe["Übernahme"]
+    )
     plotframe.to_csv(snakemake.output.trassenlaenge_csv)
+
 
 def plot_NEP(df, savepath=None, gleichschaltung=True):
     key = "Investment|Energy Supply|Electricity|Transmission|"
@@ -127,7 +129,7 @@ def plot_NEP(df, savepath=None, gleichschaltung=True):
         "exogen": [
             df.loc[key + "DC|NEP|Onshore"].values.sum() * 5,
             df.loc[key + "AC|NEP|Onshore"].values.sum() * 5,
-            0, # see "Übernahme"
+            0,  # see "Übernahme"
             None,
             df.loc[key + "NEP|Offshore"].values.sum() * 5,
         ],
@@ -135,17 +137,19 @@ def plot_NEP(df, savepath=None, gleichschaltung=True):
             (
                 df.loc[key + "DC|Onshore"].values
                 - df.loc[key + "DC|NEP|Onshore"].values
-            ).sum() * 5,
+            ).sum()
+            * 5,
             (
                 df.loc[key + "AC|Onshore"].values
                 - df.loc[key + "AC|NEP|Onshore"].values
-            ).sum() * 5,
+            ).sum()
+            * 5,
             0,
             None,
             (
-                df.loc[key + "Offshore"].values 
-                - df.loc[key + "NEP|Offshore"].values
-            ).sum() * 5,
+                df.loc[key + "Offshore"].values - df.loc[key + "NEP|Offshore"].values
+            ).sum()
+            * 5,
         ],
         "Übernahme": [
             0,
@@ -158,7 +162,9 @@ def plot_NEP(df, savepath=None, gleichschaltung=True):
 
     plotframe = pd.DataFrame(data)
     plotframe.set_index("Kategorie", inplace=True)
-    plotframe.loc["Onshore"] = plotframe.loc[["AC", "DC", "System-\ndienstleistungen"]].sum()
+    plotframe.loc["Onshore"] = plotframe.loc[
+        ["AC", "DC", "System-\ndienstleistungen"]
+    ].sum()
     # Define the width of the bars
     bar_width = 0.35
     indices = np.arange(len(plotframe))  # Bar positions
@@ -201,26 +207,36 @@ def plot_NEP(df, savepath=None, gleichschaltung=True):
     plt.xticks(indices + bar_width / 2, plotframe.index)
     plt.legend()
 
-
-
-
     # Rename the category to remove the format string again
-    plotframe.rename(index={"System-\ndienstleistungen": "Systemdienstleistungen"}, inplace=True)
+    plotframe.rename(
+        index={"System-\ndienstleistungen": "Systemdienstleistungen"}, inplace=True
+    )
     plotframe["NEP-Total"] = plotframe["Startnetz"] + plotframe["Zubaunetz"]
-    plotframe["PyPSA-Total"] = plotframe["exogen"] + plotframe["endogen"] + plotframe["Übernahme"]
+    plotframe["PyPSA-Total"] = (
+        plotframe["exogen"] + plotframe["endogen"] + plotframe["Übernahme"]
+    )
 
     # Add total costs annotations
 
     plt.text(
-        1.05, 0.95, f"NEP: {round(plotframe.loc["Onshore","NEP-Total"] + plotframe.loc["Offshore","NEP-Total"],1)}", transform=plt.gca().transAxes,
-        fontsize=12, verticalalignment='top', bbox=dict(facecolor='white', alpha=0.5)
+        1.05,
+        0.95,
+        f"NEP: {round(plotframe.loc["Onshore","NEP-Total"] + plotframe.loc["Offshore","NEP-Total"],1)}",
+        transform=plt.gca().transAxes,
+        fontsize=12,
+        verticalalignment="top",
+        bbox=dict(facecolor="white", alpha=0.5),
     )
     plt.text(
-        1.05, 0.85, f"PyPSA: {round(plotframe.loc["Onshore","PyPSA-Total"] + plotframe.loc["Offshore","PyPSA-Total"],1)}", transform=plt.gca().transAxes,
-        fontsize=12, verticalalignment='top', bbox=dict(facecolor='white', alpha=0.5)
+        1.05,
+        0.85,
+        f"PyPSA: {round(plotframe.loc["Onshore","PyPSA-Total"] + plotframe.loc["Offshore","PyPSA-Total"],1)}",
+        transform=plt.gca().transAxes,
+        fontsize=12,
+        verticalalignment="top",
+        bbox=dict(facecolor="white", alpha=0.5),
     )
 
-    
     if savepath:
         plt.savefig(savepath, bbox_inches="tight")
     else:


### PR DESCRIPTION
- Consider links starting with DC **as well as** TYNDP as NEP projects
- Restrict NEP projects to the current planning horizon (if they are expanded further in other planning horizons, this is accounted as endogenous)
- Change the Trassen units (see discord)
- slightly improve the NEP plots

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
