### PR TITLE
remove length_factor because it's multiplied already during clustering

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -222,7 +222,6 @@ rule modify_prenetwork:
         enable_kernnetz=config_provider("wasserstoff_kernnetz", "enable"),
         costs=config_provider("costs"),
         max_hours=config_provider("electricity", "max_hours"),
-        length_factor=config_provider("lines", "length_factor"),
         technology_occurrence=config_provider("first_technology_occurrence"),
         fossil_boiler_ban=config_provider("new_decentral_fossil_boiler_ban"),
         coal_ban=config_provider("coal_generation_ban"),

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -706,16 +706,16 @@ def unravel_gasbus(n, costs):
 
 
 def transmission_costs_from_modified_cost_data(
-    n, costs, transmission, length_factor=1.0
+    n, costs, transmission
 ):
     # copying the the function update_transmission_costs from add_electricity
     # slight change to the function so it works in modify_prenetwork
 
     n.lines["capital_cost"] = (
-        n.lines["length"] * length_factor * costs.at["HVAC overhead", "capital_cost"]
+        n.lines["length"] * costs.at["HVAC overhead", "capital_cost"]
     )
     n.lines["overnight_cost"] = (
-        n.lines["length"] * length_factor * costs.at["HVAC overhead", "investment"]
+        n.lines["length"] * costs.at["HVAC overhead", "investment"]
     )
 
     if n.links.empty:
@@ -735,7 +735,6 @@ def transmission_costs_from_modified_cost_data(
 
     capital_cost = (
         n.links.loc[dc_b, "length"]
-        * length_factor
         * (
             (1.0 - n.links.loc[dc_b, "underwater_fraction"])
             * costs.at[links_costs, "capital_cost"]
@@ -747,7 +746,6 @@ def transmission_costs_from_modified_cost_data(
 
     overnight_cost = (
         n.links.loc[dc_b, "length"]
-        * length_factor
         * (
             (1.0 - n.links.loc[dc_b, "underwater_fraction"])
             * costs.at[links_costs, "investment"]
@@ -1231,7 +1229,6 @@ if __name__ == "__main__":
         n,
         costs_loaded,
         snakemake.params.transmission_costs,
-        snakemake.params.length_factor,
     )
 
     if snakemake.params.biogas_must_run["enable"]:


### PR DESCRIPTION
Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
