### PR TITLE
Improve solar and wind modeling

### DIFF
--- a/ariadne-data/offshore_connection_points.csv
+++ b/ariadne-data/offshore_connection_points.csv
@@ -17,8 +17,8 @@ NOR-3-3,,DC-ONAS NOR-3-3 (DolWin6),Emden / Ost (TenneT),90.0,900,2023.0,NEP2023 
 NOR-6-3,,DC-ONAS NOR-6-3 (BorWin4),Hanekenfähr (Amprion),264.0,900,2028.0,NEP2023 Startnetz,52.475798,7.307034
 NOR-7-1,,DC-ONAS NOR-7-1 (BorWin5),Garrel / Ost (TenneT),225.0,900,2025.0,NEP2023 Startnetz,52.945885,8.075682
 NOR-7-2,,DC-ONAS NOR-7-2 (BorWin6),Büttel (TenneT),235.0,980,2027.0,NEP2023 Startnetz,53.917758,9.234576
-NOR-9-1,M243,HGÜ-Verbindung NOR-9-1 (BalWin1),Wehrendorf (Amprion),363.0,2000,2029.0,Szenario B/C 2045,52.347253,8.307983
-NOR-9-2,M236,HGÜ-Verbindung NOR-9-2 (BalWin3),Wilhelmshaven 2 (TenneT),250.0,2000,2029.0,Szenario B/C 2045,53.56214,8.12915
+NOR-9-1,M243,HGÜ-Verbindung NOR-9-1 (BalWin1),Wehrendorf (Amprion),363.0,2000,2030.0,Szenario B/C 2045,52.347253,8.307983
+NOR-9-2,M236,HGÜ-Verbindung NOR-9-2 (BalWin3),Wilhelmshaven 2 (TenneT),250.0,2000,2031.0,Szenario B/C 2045,53.56214,8.12915
 NOR-9-3,M234,HGÜ-Verbindung NOR-9-3 (BalWin4),Unterweser (TenneT),265.0,2000,2029.0,Szenario B/C 2045,53.428708,8.472726
 NOR-10-1,M39,HGÜ-Verbindung NOR-10-1 (BalWin2),Westerkappeln (Amprion),371.0,2000,2030.0,Szenario B/C 2045,52.275966,7.887789
 NOR-11-1,M233,HGÜ-Verbindung NOR-11-1 (LanWin3),Suchraum Heide (50Hertz),215.0,2000,2030.0,Szenario B/C 2045,54.16277,9.05231

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -104,6 +104,7 @@ atlite:
 
 renewable:
   onwind:
+    capacity_per_sqkm: 2
     cutout: europe-2019-sarah3-era5
     resource:
       smooth: false  #this is false until correction to onshore wind speeds from GWA implemented

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -106,6 +106,7 @@ renewable:
   onwind:
     capacity_per_sqkm: 2
     cutout: europe-2019-sarah3-era5
+    correction_factor: 0.95
     resource:
       smooth: false  #this is false until correction to onshore wind speeds from GWA implemented
       #based on Vestas_V112_3MW, but changing hub_height from 80m with time
@@ -129,6 +130,7 @@ renewable:
     capacity_per_sqkm: 6
     landfall_length: 30
     cutout: europe-2019-sarah3-era5
+    correction_factor: 0.95
     resource:
       smooth: true
       #based on NREL_ReferenceTurbine_2020ATB_5.5MW, but changing hub_height from 80m with time
@@ -152,6 +154,7 @@ renewable:
     capacity_per_sqkm: 6
     landfall_length: 30
     cutout: europe-2019-sarah3-era5
+    correction_factor: 0.95
     resource:
       smooth: true
       #based on NREL_ReferenceTurbine_2020ATB_5.5MW, but changing hub_height from 80m with time
@@ -175,12 +178,13 @@ renewable:
     landfall_length: 30
     capacity_per_sqkm: 6
     cutout: europe-2019-sarah3-era5
+    correction_factor: 0.95
   solar:
     cutout: europe-2019-sarah3-era5
-    correction_factor: 0.918 # scaling to Abbildung 36 of https://www.ise.fraunhofer.de/de/veroeffentlichungen/studien/aktuelle-fakten-zur-photovoltaik-in-deutschland.html
+    correction_factor: 0.9 # scaling to Abbildung 36 of https://www.ise.fraunhofer.de/de/veroeffentlichungen/studien/aktuelle-fakten-zur-photovoltaik-in-deutschland.html
   solar-hsat:
     cutout: europe-2019-sarah3-era5
-    correction_factor: 0.918 # scaling to Abbildung 36 of https://www.ise.fraunhofer.de/de/veroeffentlichungen/studien/aktuelle-fakten-zur-photovoltaik-in-deutschland.html
+    correction_factor: 0.9 # scaling to Abbildung 36 of https://www.ise.fraunhofer.de/de/veroeffentlichungen/studien/aktuelle-fakten-zur-photovoltaik-in-deutschland.html
   hydro:
     cutout: europe-2019-sarah3-era5
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -441,7 +441,7 @@ solving:
           DE:
             2020: 7.8
             2025: 11.3
-            2030: 31.3 # uba Projektionsbericht
+            2030: 29.3 # uba Projektionsbericht and NEP without delayed BalWin 3
             2035: 70
             2040: 70
             2045: 70

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -494,9 +494,9 @@ def _get_capacities(n, region, cap_func, cap_string="Capacity|"):
     # var[cap_string + "Electricity|Gas|CC|w/o CCS"] =
     # ! Not implemented, rarely used
 
-    var[cap_string + "Electricity|Gas|CC"] = capacities_electricity.get("CCGT")
+    var[cap_string + "Electricity|Gas|CC"] = capacities_electricity.get("CCGT", 0)
 
-    var[cap_string + "Electricity|Gas|OC"] = capacities_electricity.get("OCGT")
+    var[cap_string + "Electricity|Gas|OC"] = capacities_electricity.get("OCGT", 0)
 
     var[cap_string + "Electricity|Gas|w/ CCS"] = capacities_electricity.get(
         "urban central gas CHP CC", 0


### PR DESCRIPTION
This PR does several things:

- The correction_factor for solar introduced in https://github.com/PyPSA/pypsa-ariadne/pull/225 is adjusted downwards to 0.9. The reason was a higher capacity factor observed for solar in the latest 3H and 30 nodes (for DE) runs. Besides, in hindsight, it seems overengineered to pick a very precise number for something that is not know that exactly, and that we don't expect to be exact in our model. Afterall we are mixing 2020 capacities with a 2019 weather year and extrapolate that into the future. So, 0.9 is a nice number, does the job, and was stated by Tom as the maximum acceptable correction factor before the linear downscale would distort peak capacity (and thus required Netzausbau) too much.
- For similar reasons a correction_factor of 0.95 was introduced for offwind. We are orienting towards the follwing data:

![image(1)](https://github.com/user-attachments/assets/4cd657dd-8451-4120-bd87-95e862d18960)

- We take over an expected delay in one of the offshore projects (closes #283).

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
