### PR TITLE
bugfix: revert must run if no more indicated

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241121-fix-missing-gas-capa
+  prefix: 20241202-fix-must-run-bug
 
   name:
   # - CurrentPolicies
@@ -652,8 +652,8 @@ pypsa_eur:
 
 
 co2_price_add_on_fossils:
-  2020: 25
-  2025: 60
+  # 2020: 25
+  # 2025: 60
 
 must_run:
   2020:

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -178,8 +178,9 @@ def write_to_scenario_yaml(input, output, scenarios, df):
             df.loc[:, fallback_reference_scenario, :], planning_horizons
         )
 
-
-        if reference_scenario.startswith("KN2045plus"): # Still waiting for REMIND uploads
+        if reference_scenario.startswith(
+            "KN2045plus"
+        ):  # Still waiting for REMIND uploads
             fallback_reference_scenario = reference_scenario
 
         co2_budget_source = config[scenario]["co2_budget_DE_source"]

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -4130,7 +4130,9 @@ def get_policy(n, investment_year):
     var = pd.Series()
 
     # add carbon component to fossil fuels if specified
-    if (snakemake.params.co2_price_add_on_fossils is not None) and (investment_year in snakemake.params.co2_price_add_on_fossils.keys()):
+    if (snakemake.params.co2_price_add_on_fossils is not None) and (
+        investment_year in snakemake.params.co2_price_add_on_fossils.keys()
+    ):
         co2_price_add_on = snakemake.params.co2_price_add_on_fossils[investment_year]
     else:
         co2_price_add_on = 0.0

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -4130,7 +4130,7 @@ def get_policy(n, investment_year):
     var = pd.Series()
 
     # add carbon component to fossil fuels if specified
-    if investment_year in snakemake.params.co2_price_add_on_fossils.keys():
+    if (snakemake.params.co2_price_add_on_fossils is not None) and (investment_year in snakemake.params.co2_price_add_on_fossils.keys()):
         co2_price_add_on = snakemake.params.co2_price_add_on_fossils[investment_year]
     else:
         co2_price_add_on = 0.0

--- a/workflow/scripts/modify_cost_data.py
+++ b/workflow/scripts/modify_cost_data.py
@@ -117,7 +117,7 @@ if __name__ == "__main__":
 
     # add carbon component to fossil fuel costs
     investment_year = int(snakemake.wildcards.planning_horizons[-4:])
-    if investment_year in snakemake.params.co2_price_add_on_fossils.keys():
+    if (snakemake.params.co2_price_add_on_fossils is not None) and (investment_year in snakemake.params.co2_price_add_on_fossils.keys()):
         co2_price = snakemake.params.co2_price_add_on_fossils[investment_year]
         logger.info(
             f"Adding carbon component according to a co2 price of {co2_price} €/t to fossil fuel costs."

--- a/workflow/scripts/modify_cost_data.py
+++ b/workflow/scripts/modify_cost_data.py
@@ -117,7 +117,9 @@ if __name__ == "__main__":
 
     # add carbon component to fossil fuel costs
     investment_year = int(snakemake.wildcards.planning_horizons[-4:])
-    if (snakemake.params.co2_price_add_on_fossils is not None) and (investment_year in snakemake.params.co2_price_add_on_fossils.keys()):
+    if (snakemake.params.co2_price_add_on_fossils is not None) and (
+        investment_year in snakemake.params.co2_price_add_on_fossils.keys()
+    ):
         co2_price = snakemake.params.co2_price_add_on_fossils[investment_year]
         logger.info(
             f"Adding carbon component according to a co2 price of {co2_price} €/t to fossil fuel costs."

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -770,21 +770,45 @@ def transmission_costs_from_modified_cost_data(n, costs, transmission):
 
 def must_run(n, params):
     """
-    Set p_min_pu for links to the specified value.
+    Set p_min_pu for links to the specified value or reset to 0 if not specified.
     """
+    
     investment_year = int(snakemake.wildcards.planning_horizons)
-    if investment_year in params.keys():
-        for region in params[investment_year].keys():
-            for carrier in params[investment_year][region].keys():
-                p_min_pu = params[investment_year][region][carrier]
-                logger.info(
-                    f"Must-run condition enabled: Setting p_min_pu = {p_min_pu} for {carrier} in year {investment_year} and region {region}."
-                )
+    planning_horizons = snakemake.params.planning_horizons
+    i = planning_horizons.index(int(snakemake.wildcards.planning_horizons))
+    previous_investment_year = int(planning_horizons[i - 1]) if i != 0 else np.nan
 
+    # Get params for the current and previous years
+    current_params = params.get(investment_year, {})
+    previous_params = params.get(previous_investment_year, {})
+
+    # Collect all carriers and regions from the previous period
+    for region in previous_params:
+        for carrier in previous_params[region]:
+            # Check if the carrier is not in the current period
+            if region not in current_params or carrier not in current_params.get(region, {}):
+                # Reset p_min_pu to 0 for this carrier in the previous region
+                logger.info(
+                    f"Must-run condition disabled: Resetting p_min_pu to 0 for {carrier} "
+                    f"in region {region} (was specified in {previous_investment_year}, but not in {investment_year})."
+                )
                 links_i = n.links[
                     (n.links.carrier == carrier) & n.links.index.str.contains(region)
                 ].index
-                n.links.loc[links_i, "p_min_pu"] = p_min_pu
+                n.links.loc[links_i, "p_min_pu"] = 0
+
+    # Set p_min_pu for carriers specified in the current investment period
+    for region in current_params:
+        for carrier in current_params[region]:
+            p_min_pu = current_params[region][carrier]
+            logger.info(
+                f"Must-run condition enabled: Setting p_min_pu = {p_min_pu} for {carrier} "
+                f"in year {investment_year} and region {region}."
+            )
+            links_i = n.links[
+                (n.links.carrier == carrier) & n.links.index.str.contains(region)
+            ].index
+            n.links.loc[links_i, "p_min_pu"] = p_min_pu
 
 
 def aladin_mobility_demand(n):
@@ -1247,7 +1271,7 @@ if __name__ == "__main__":
             opts="",
             ll="vopt",
             sector_opts="none",
-            planning_horizons="2020",
+            planning_horizons="2025",
             run="KN2045_Bal_v4",
         )
 

--- a/workflow/scripts/modify_prenetwork.py
+++ b/workflow/scripts/modify_prenetwork.py
@@ -772,7 +772,7 @@ def must_run(n, params):
     """
     Set p_min_pu for links to the specified value or reset to 0 if not specified.
     """
-    
+
     investment_year = int(snakemake.wildcards.planning_horizons)
     planning_horizons = snakemake.params.planning_horizons
     i = planning_horizons.index(int(snakemake.wildcards.planning_horizons))
@@ -786,7 +786,9 @@ def must_run(n, params):
     for region in previous_params:
         for carrier in previous_params[region]:
             # Check if the carrier is not in the current period
-            if region not in current_params or carrier not in current_params.get(region, {}):
+            if region not in current_params or carrier not in current_params.get(
+                region, {}
+            ):
                 # Reset p_min_pu to 0 for this carrier in the previous region
                 logger.info(
                     f"Must-run condition disabled: Resetting p_min_pu to 0 for {carrier} "


### PR DESCRIPTION
- add functionality to revert must run conditions if no more explicitly specified in current investment year (reason: bug)
-  do no more apply co2 price additions on fossils in 2020, 2025 (reason: co2 price in 2025 is already at around 40 €/tC02)

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [x] The logic of `export_ariadne_variables` has been adapted to the changes
- [x] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
