### PR TITLE
Improve waste sector

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+- Increase HVC_environment_sequestration_fraction from 0.1 to 0.6
+- Disallow HVC to air in DE
 - Restricting the maximum capacity of CurrentPolicies and minus scenarios to the 'uba Projektionsbericht'
 - Restricting Fischer Tropsch capacity addition with config[solving][limit_DE_FT_cap]
 - Except for Current Policies force a minimum of 5 GW of electrolysis capacity in Germany

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -394,13 +394,13 @@ industry:
     2045: 0.16
     2050: 0.20
   HVC_environment_sequestration_fraction:
-    2020: 0.1
-    2025: 0.1
-    2030: 0.12
-    2035: 0.15
-    2040: 0.18
-    2045: 0.20
-    2050: 0.20
+    2020: 0.6
+    2025: 0.6
+    2030: 0.6
+    2035: 0.6
+    2040: 0.6
+    2045: 0.6
+    2050: 0.6
   waste_to_energy: true
   waste_to_energy_cc: true
 
@@ -482,12 +482,12 @@ solving:
             2045: 2.5
         HVC to air:
           DE:
-            2020: 9
-            2025: 8
-            2030: 7
-            2035: 6
-            2040: 5
-            2045: 4
+            2020: 0
+            2025: 0
+            2030: 0
+            2035: 0
+            2040: 0
+            2045: 0
     limits_capacity_min:
       Generator:
         onwind:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241121-fix-missing-gas-capa
+  prefix: 20241202-more-waste-CHP
 
   name:
   # - CurrentPolicies
@@ -480,6 +480,14 @@ solving:
             2035: 2.5
             2040: 2.5
             2045: 2.5
+        HVC to air:
+          DE:
+            2020: 9
+            2025: 8
+            2030: 7
+            2035: 6
+            2040: 5
+            2045: 4
     limits_capacity_min:
       Generator:
         onwind:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -393,7 +393,7 @@ industry:
     2040: 0.12
     2045: 0.16
     2050: 0.20
-  # 15 Mt HVC production (from IDEES) -> 6 Mt Plastikabfälle, 
+  # 15 Mt HVC production (from IDEES) -> 6 Mt Plastikabfälle,
   # To substitute for other waste, assume all Plastikabfall is used energetically whereas in reality ~40% is recycled
   # see https://github.com/PyPSA/pypsa-ariadne/pull/292
   HVC_environment_sequestration_fraction:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -393,6 +393,9 @@ industry:
     2040: 0.12
     2045: 0.16
     2050: 0.20
+  # 15 Mt HVC production (from IDEES) -> 6 Mt Plastikabfälle, 
+  # To substitute for other waste, assume all Plastikabfall is used energetically whereas in reality ~40% is recycled
+  # see https://github.com/PyPSA/pypsa-ariadne/pull/292
   HVC_environment_sequestration_fraction:
     2020: 0.6
     2025: 0.6
@@ -482,7 +485,7 @@ solving:
             2045: 2.5
         HVC to air:
           DE:
-            2020: 0
+            2020: 0 # all HVC in Germany is either burned or recycled
             2025: 0
             2030: 0
             2035: 0

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -178,8 +178,9 @@ def write_to_scenario_yaml(input, output, scenarios, df):
             df.loc[:, fallback_reference_scenario, :], planning_horizons
         )
 
-
-        if reference_scenario.startswith("KN2045plus"): # Still waiting for REMIND uploads
+        if reference_scenario.startswith(
+            "KN2045plus"
+        ):  # Still waiting for REMIND uploads
             fallback_reference_scenario = reference_scenario
 
         co2_budget_source = config[scenario]["co2_budget_DE_source"]

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -2876,7 +2876,7 @@ def get_emissions(n, region, _energy_totals, industry_demand):
     ) + var["Emissions|Gross Fossil CO2|Energy|Supply|Gases"]
 
     var["Emissions|CO2|Supply|Non-Renewable Waste"] = (
-        co2_emissions.get("HVC to air").sum() + waste_CHP_emissions.sum()
+        co2_emissions.get("HVC to air", 0) + waste_CHP_emissions.sum()
     )
 
     var["Emissions|Gross Fossil CO2|Energy|Supply|Liquids"] = co2_emissions.get(

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -2403,7 +2403,7 @@ def get_final_energy(
         .multiply(MWh2PJ)
     )
 
-    var["Final Energy|Waste"] = waste_withdrawal.filter(like="waste CHP").sum()
+    var["Final Energy|Waste"] = waste_withdrawal.get("HVC to air", 0)
 
     var["Final Energy|Carbon Dioxide Removal|Heat"] = decentral_heat_withdrawal.get(
         "DAC", 0
@@ -2699,17 +2699,13 @@ def get_emissions(n, region, _energy_totals, industry_demand):
 
     negative_CHP_E_fraction = negative_CHP_E_to_H * (1 / (negative_CHP_E_to_H + 1))
 
-    # separate waste CHPs, because they are accounted differently
-    waste_CHP_emissions = CHP_emissions.filter(like="waste")
-    CHP_emissions = CHP_emissions.drop(waste_CHP_emissions.index)
-
     # It would be interesting to relate the Emissions|CO2|Model to Emissions|CO2 reported to the DB by considering imports of carbon, e.g., (exports_oil_renew - imports_oil_renew) * 0.2571 * t2Mt + (exports_gas_renew - imports_gas_renew) * 0.2571 * t2Mt + (exports_meoh - imports_meoh) / 4.0321 * t2Mt
     # Then it would be necessary to consider negative carbon from solid biomass imports as well
     # Actually we might have to include solid biomass imports in the co2 constraints as well
 
     assert isclose(
         co2_emissions.filter(like="CHP").sum(),
-        CHP_emissions.sum() + waste_CHP_emissions.sum(),
+        CHP_emissions.sum(),
     )
     assert isclose(
         co2_atmosphere_withdrawal.filter(like="CHP").sum(),
@@ -2876,7 +2872,7 @@ def get_emissions(n, region, _energy_totals, industry_demand):
     ) + var["Emissions|Gross Fossil CO2|Energy|Supply|Gases"]
 
     var["Emissions|CO2|Supply|Non-Renewable Waste"] = (
-        co2_emissions.get("HVC to air", 0) + waste_CHP_emissions.sum()
+        co2_emissions.get("HVC to air", 0)
     )
 
     var["Emissions|Gross Fossil CO2|Energy|Supply|Liquids"] = co2_emissions.get(

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -2871,9 +2871,7 @@ def get_emissions(n, region, _energy_totals, industry_demand):
         "biogas to gas CC", 0
     ) + var["Emissions|Gross Fossil CO2|Energy|Supply|Gases"]
 
-    var["Emissions|CO2|Supply|Non-Renewable Waste"] = (
-        co2_emissions.get("HVC to air", 0)
-    )
+    var["Emissions|CO2|Supply|Non-Renewable Waste"] = co2_emissions.get("HVC to air", 0)
 
     var["Emissions|Gross Fossil CO2|Energy|Supply|Liquids"] = co2_emissions.get(
         "oil refining", 0

--- a/workflow/scripts/plot_ariadne_variables.py
+++ b/workflow/scripts/plot_ariadne_variables.py
@@ -308,8 +308,8 @@ def plot_NEP(df, savepath=None, gleichschaltung=True, currency_year=2020):
     )
 
     plt.xlabel("Kategorie")
-    plt.ylabel("Milliarden EUR{currency_year}")
-    plt.title("Investitionen ins Übertragungsnetz in EUR{currency_year}")
+    plt.ylabel(f"Milliarden EUR{currency_year}")
+    plt.title(f"Investitionen ins Übertragungsnetz in EUR{currency_year}")
 
     # Adjust the x-ticks to be between the two bars
     plt.xticks(indices + bar_width / 2, plotframe.index)


### PR DESCRIPTION
Previously the model did not utilize waste CHPs in 2020. This PR:

- Accounts emissions from waste CHPs just like for other CHPs in the energy sector
- Sets 0 capacity for `HVC to air` in DE, because >99% of Plastikabfall are used energetically or recycled
- Set `HVC_environment_sequestration_fraction` to 0.6, which is more aligned with official statistics. 

Caveat: For Germany a more correct sequestration_fraction. would be 0.8. However, since we do not model other types of waste, we allow for a higher HVC input to waste CHPs. This way we get rough alignment with JRC-IDEES statistics on CO2  emissions from the burning of waste, as well as with the UBA statistics on energy generated from waste. For discussion and references see the comments below.

- ~~Adds a maximum capacity for the `HVC to air` links, in order to force utilization of waste CHPs for the remaining MWh_HVC. The Capacity limit is chosen such that - assuming that the `HVC to air` links are fully utilized in 2020 - the remaining MWh_HVC correspond roughly with official statistics for energetic use.~~

Source: https://www.umweltbundesamt.de/sites/default/files/medien/1410/publikationen/2018-06-26_texte_51-2018_energieerzeugung-abfaelle.pdf

![image](https://github.com/user-attachments/assets/eb1a4a6c-0721-44af-84c6-442b14c50489)



Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [x] The logic of `export_ariadne_variables` has been adapted to the changes
- [x] One or several figures that validate the changes in the PR have been posted as a comment
- [x] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
