### PR TITLE
Adjusting Aviation Demand and Emission Accounting

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Changelog
+- Adjusting aviation demand (from Aladin) and emission accounting (only domestic aviation for national target)
 - Restricting the maximum capacity of CurrentPolicies and minus scenarios to the 'uba Projektionsbericht'
 - Restricting Fischer Tropsch capacity addition with config[solving][limit_DE_FT_cap]
 - Except for Current Policies force a minimum of 5 GW of electrolysis capacity in Germany

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -284,8 +284,6 @@ costs:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
-  domestic_aviation_factor:
-    DE: 0.07 # eurostat 2019
   v2g: false
   solar_thermal: false
   district_heating:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241121-fix-missing-gas-capa
+  prefix: 20241203-fix-aviation
 
   name:
   # - CurrentPolicies
@@ -284,6 +284,8 @@ costs:
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#sector
 sector:
+  domestic_aviation_factor:
+    DE: 0.07 # eurostat 2019
   v2g: false
   solar_thermal: false
   district_heating:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -302,6 +302,7 @@ use rule solve_sector_network_myopic from pypsaeur with:
         custom_extra_functionality=os.path.join(
             os.path.dirname(workflow.snakefile), "scripts/additional_functionality.py"
         ),
+        energy_year=config_provider("energy", "energy_totals_year"),
     input:
         **{
             k: v
@@ -311,6 +312,7 @@ use rule solve_sector_network_myopic from pypsaeur with:
         network=RESULTS
         + "prenetworks-final/base_s_{clusters}_l{ll}_{opts}_{sector_opts}_{planning_horizons}.nc",
         co2_totals_name=resources("co2_totals.csv"),
+        energy_totals=resources("energy_totals.csv"),
 
 
 rule modify_existing_heating:

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -398,7 +398,10 @@ def add_co2limit_country(n, limit_countries, snakemake, debug=False):
             )
 
         # Aviation demand
-        domestic_factor = snakemake.config["sector"]["domestic_aviation_factor"]["DE"]
+        energy_totals = pd.read_csv(snakemake.input.energy_totals, index_col=[0, 1])
+        domestic_aviation = energy_totals.loc[("DE", snakemake.params.energy_year), "total domestic aviation"]
+        international_aviation = energy_totals.loc[("DE", snakemake.params.energy_year), "total international aviation"]
+        domestic_factor = domestic_aviation / (domestic_aviation + international_aviation)
         aviation_links = n.links[
             (n.links.index.str[:2] == ct) & (n.links.carrier == "kerosene for aviation")
         ]

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -373,7 +373,9 @@ def add_co2limit_country(n, limit_countries, snakemake, debug=False):
             links = n.links.index[
                 (n.links.index.str[:2] == ct)
                 & (n.links[f"bus{port}"] == "co2 atmosphere")
-                & (n.links.carrier != "kerosene for aviation") # first exclude aviation to multiply it with a domestic factor later
+                & (
+                    n.links.carrier != "kerosene for aviation"
+                )  # first exclude aviation to multiply it with a domestic factor later
             ]
 
             logger.info(
@@ -398,16 +400,17 @@ def add_co2limit_country(n, limit_countries, snakemake, debug=False):
         # Aviation demand
         domestic_factor = snakemake.config["sector"]["domestic_aviation_factor"]["DE"]
         aviation_links = n.links[
-            (n.links.index.str[:2] == ct)
-            & (n.links.carrier == "kerosene for aviation")
+            (n.links.index.str[:2] == ct) & (n.links.carrier == "kerosene for aviation")
         ]
         lhs.append
         (
-                n.model["Link-p"].loc[:, aviation_links.index]
-                * aviation_links.efficiency2
-                * n.snapshot_weightings.generators
+            n.model["Link-p"].loc[:, aviation_links.index]
+            * aviation_links.efficiency2
+            * n.snapshot_weightings.generators
         ).sum() * domestic_factor
-        logger.info(f"Adding domestic aviation emissions for {ct} with a factor of {domestic_factor}")
+        logger.info(
+            f"Adding domestic aviation emissions for {ct} with a factor of {domestic_factor}"
+        )
 
         # Adding Efuel imports and exports to constraint
         incoming_oil = n.links.index[n.links.index == "EU renewable oil -> DE oil"]

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -399,9 +399,15 @@ def add_co2limit_country(n, limit_countries, snakemake, debug=False):
 
         # Aviation demand
         energy_totals = pd.read_csv(snakemake.input.energy_totals, index_col=[0, 1])
-        domestic_aviation = energy_totals.loc[("DE", snakemake.params.energy_year), "total domestic aviation"]
-        international_aviation = energy_totals.loc[("DE", snakemake.params.energy_year), "total international aviation"]
-        domestic_factor = domestic_aviation / (domestic_aviation + international_aviation)
+        domestic_aviation = energy_totals.loc[
+            ("DE", snakemake.params.energy_year), "total domestic aviation"
+        ]
+        international_aviation = energy_totals.loc[
+            ("DE", snakemake.params.energy_year), "total international aviation"
+        ]
+        domestic_factor = domestic_aviation / (
+            domestic_aviation + international_aviation
+        )
         aviation_links = n.links[
             (n.links.index.str[:2] == ct) & (n.links.carrier == "kerosene for aviation")
         ]

--- a/workflow/scripts/additional_functionality.py
+++ b/workflow/scripts/additional_functionality.py
@@ -373,6 +373,7 @@ def add_co2limit_country(n, limit_countries, snakemake, debug=False):
             links = n.links.index[
                 (n.links.index.str[:2] == ct)
                 & (n.links[f"bus{port}"] == "co2 atmosphere")
+                & (n.links.carrier != "kerosene for aviation") # first exclude aviation to multiply it with a domestic factor later
             ]
 
             logger.info(
@@ -393,6 +394,20 @@ def add_co2limit_country(n, limit_countries, snakemake, debug=False):
                     * n.snapshot_weightings.generators
                 ).sum()
             )
+
+        # Aviation demand
+        domestic_factor = snakemake.config["sector"]["domestic_aviation_factor"]["DE"]
+        aviation_links = n.links[
+            (n.links.index.str[:2] == ct)
+            & (n.links.carrier == "kerosene for aviation")
+        ]
+        lhs.append
+        (
+                n.model["Link-p"].loc[:, aviation_links.index]
+                * aviation_links.efficiency2
+                * n.snapshot_weightings.generators
+        ).sum() * domestic_factor
+        logger.info(f"Adding domestic aviation emissions for {ct} with a factor of {domestic_factor}")
 
         # Adding Efuel imports and exports to constraint
         incoming_oil = n.links.index[n.links.index == "EU renewable oil -> DE oil"]

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -178,8 +178,9 @@ def write_to_scenario_yaml(input, output, scenarios, df):
             df.loc[:, fallback_reference_scenario, :], planning_horizons
         )
 
-
-        if reference_scenario.startswith("KN2045plus"): # Still waiting for REMIND uploads
+        if reference_scenario.startswith(
+            "KN2045plus"
+        ):  # Still waiting for REMIND uploads
             fallback_reference_scenario = reference_scenario
 
         co2_budget_source = config[scenario]["co2_budget_DE_source"]

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -139,10 +139,7 @@ def get_co2_budget(df, source):
 
     ## PyPSA disregards nonco2 GHG emissions, but includes bunkers
 
-    targets_pypsa = (
-        targets_co2
-        - nonco2
-    )
+    targets_pypsa = targets_co2 - nonco2
 
     target_fractions_pypsa = targets_pypsa.loc[targets_co2.index] / baseline_pypsa
 

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -19,7 +19,7 @@ import ruamel.yaml
 
 def get_transport_growth(df, planning_horizons):
     # Aviation growth factor - using REMIND-EU v1.1 since Aladin v1 does not include bunkers
-    aviation_model = snakemake.params.leitmodelle["general"]
+    aviation_model = snakemake.params.leitmodelle["transport"]
     try:
         aviation = df.loc[aviation_model, "Final Energy|Bunkers|Aviation", "PJ/yr"]
     except KeyError:

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -18,13 +18,11 @@ import ruamel.yaml
 
 
 def get_transport_growth(df, planning_horizons):
-    # Aviation growth factor - using REMIND-EU v1.1 since Aladin v1 does not include bunkers
-    aviation_model = snakemake.params.leitmodelle["transport"]
     try:
-        aviation = df.loc[aviation_model, "Final Energy|Bunkers|Aviation", "PJ/yr"]
+        aviation = df.loc["Final Energy|Bunkers|Aviation", "PJ/yr"]
     except KeyError:
         aviation = (
-            df.loc[aviation_model, "Final Energy|Bunkers|Aviation", "TWh/yr"] * 3.6
+            df.loc["Final Energy|Bunkers|Aviation", "TWh/yr"] * 3.6
         )  # TWh to PJ
 
     aviation_growth_factor = aviation / aviation[2020]
@@ -156,10 +154,6 @@ def write_to_scenario_yaml(input, output, scenarios, df):
         fallback_reference_scenario = config[scenario]["iiasa_database"][
             "fallback_reference_scenario"
         ]
-        if fallback_reference_scenario != reference_scenario:
-            logger.warning(
-                f"For aviation demand, using {fallback_reference_scenario} as fallback reference scenario for {scenario}."
-            )
 
         planning_horizons = [
             2020,
@@ -171,7 +165,7 @@ def write_to_scenario_yaml(input, output, scenarios, df):
         ]  # for 2050 we still need data
 
         aviation_demand_factor = get_transport_growth(
-            df.loc[:, fallback_reference_scenario, :], planning_horizons
+            df.loc[snakemake.params.leitmodelle["transport"], reference_scenario, :], planning_horizons
         )
 
         if reference_scenario.startswith(

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -142,7 +142,6 @@ def get_co2_budget(df, source):
     targets_pypsa = (
         targets_co2
         - nonco2
-        + df.loc["Emissions|CO2|Energy|Demand|Bunkers", "Mt CO2/yr"]
     )
 
     target_fractions_pypsa = targets_pypsa.loc[targets_co2.index] / baseline_pypsa


### PR DESCRIPTION
This PR
- changes the source model for the aviation demand
- accounts only the domestic aviation in the national co2 target

Since the development of the aviation fuel demand in Remind seems implausible, the aviation demand factor is now calculated from the Aladin model.
Furthermore, only the domestic aviation demand is accounted to the national climate target. This is implemented by not relaxing the national emissions target in `build_scenarios` and in `additional_functionality` only accounting for the domestic aviation.
The share of domestic aviation can be obtained from multiple sources (all shares for 2019)
- manually JRC/IDEES: 7 %
- energy_totals.csv: 8.5 %
- Aladin: 7.4 % (no numbers for 2019 taking 2020 numbers)

Changes (before/after)
national CO2 targets (old) new
2020: (0.699) 0.671
2025: (0.552) 0.524
2030: (0.355) 0.348
2035: (0.218) 0.216
2040: (0.09) 0.09
2045: (-0.05) -0.05
2050: (-0.048) -0.048

![image](https://github.com/user-attachments/assets/a435ceba-6939-4cb6-967d-93607e167935)

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
_not applicable_
- [x] One or several figures that validate the changes in the PR have been posted as a comment
- [x] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
