### PR TITLE
Force Onshore Wind to South Germany

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 # Changelog
+- Force onwind south by increasing minimum capacity and decreasing capacity per sqkm
 - Increase HVC_environment_sequestration_fraction from 0.1 to 0.6
 - Disallow HVC to air in DE
 - Restricting the maximum capacity of CurrentPolicies and minus scenarios to the 'uba Projektionsbericht'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@
 
 # docs in https://pypsa-eur.readthedocs.io/en/latest/configuration.html#run
 run:
-  prefix: 20241202-more-waste-CHP
+  prefix: 20241203-force-onwind-south
 
   name:
   # - CurrentPolicies
@@ -104,7 +104,7 @@ atlite:
 
 renewable:
   onwind:
-    capacity_per_sqkm: 2
+    capacity_per_sqkm: 1.5
     cutout: europe-2019-sarah3-era5
     correction_factor: 0.95
     resource:
@@ -498,7 +498,7 @@ solving:
             2030: 99   # Wind-an-Land Law 2028
             2035: 115   # Wind-an-Land Law 2030
             2040: 115   # Wind-an-Land Law
-            2045: 115
+            2045: 160
         offwind:
           DE:
             2030: 22.5   # 75% Wind-auf-See Law

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -495,10 +495,10 @@ solving:
       Generator:
         onwind:
           DE:
-            2030: 99   # Wind-an-Land Law 2028
+            2030: 99    # Wind-an-Land Law 2028
             2035: 115   # Wind-an-Land Law 2030
-            2040: 115   # Wind-an-Land Law
-            2045: 160
+            2040: 157   # target 2035
+            2045: 160   # target 2040
         offwind:
           DE:
             2030: 22.5   # 75% Wind-auf-See Law

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -104,7 +104,7 @@ atlite:
 
 renewable:
   onwind:
-    capacity_per_sqkm: 1.5
+    capacity_per_sqkm: 1.4
     cutout: europe-2019-sarah3-era5
     correction_factor: 0.95
     resource:

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -659,10 +659,10 @@ KN2045minus_SupplyFocus:
         Generator:
           onwind:
             DE:
-              2030: 115 # Wind-an-Land Law
-              2035: 115 # not forcing more EE
-              2040: 115
-              2045: 115
+              2030: 86.5   # 75 % Wind-an-Land Law
+              2035: 86.5
+              2040: 86.5
+              2045: 86.5
           offwind:
             DE:
               2030: 30 # Wind-auf-See Law

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -657,6 +657,12 @@ KN2045minus_SupplyFocus:
             2045: 0
       limits_capacity_min:
         Generator:
+          onwind:
+            DE:
+              2030: 115 # Wind-an-Land Law
+              2035: 115 # not forcing more EE
+              2040: 115
+              2045: 115
           solar:
             DE:
               2025: 101

--- a/config/scenarios.manual.yaml
+++ b/config/scenarios.manual.yaml
@@ -657,13 +657,6 @@ KN2045minus_SupplyFocus:
             2045: 0
       limits_capacity_min:
         Generator:
-          onwind:
-            DE:
-              2030: 86.5 # 75% Wind-an-Land Law
-              2035: 115 # Wind-an-Land 2030
-              2040: 115 # not forcing more EE
-              2045: 115
-
           solar:
             DE:
               2025: 101

--- a/workflow/scripts/build_scenarios.py
+++ b/workflow/scripts/build_scenarios.py
@@ -21,9 +21,7 @@ def get_transport_growth(df, planning_horizons):
     try:
         aviation = df.loc["Final Energy|Bunkers|Aviation", "PJ/yr"]
     except KeyError:
-        aviation = (
-            df.loc["Final Energy|Bunkers|Aviation", "TWh/yr"] * 3.6
-        )  # TWh to PJ
+        aviation = df.loc["Final Energy|Bunkers|Aviation", "TWh/yr"] * 3.6  # TWh to PJ
 
     aviation_growth_factor = aviation / aviation[2020]
 
@@ -165,7 +163,8 @@ def write_to_scenario_yaml(input, output, scenarios, df):
         ]  # for 2050 we still need data
 
         aviation_demand_factor = get_transport_growth(
-            df.loc[snakemake.params.leitmodelle["transport"], reference_scenario, :], planning_horizons
+            df.loc[snakemake.params.leitmodelle["transport"], reference_scenario, :],
+            planning_horizons,
         )
 
         if reference_scenario.startswith(


### PR DESCRIPTION
### Problem
So far little to no onshore wind is built in the South of Germany. However, this does not represent the political targets.
![image](https://github.com/user-attachments/assets/8770bc3c-8df4-497a-899e-ca9c3fe8437e)

### Solution
By forcing more onshore wind in Germany while reducing the capacity per sqkm, onshore wind is pushed into the South of Germany. Different configs were tested:
- 160 GW - 1.5 cap_per_sqkm
total potential in Germany: 242.4 GW
total installed onshore capacity 161.249 GW
![160GW_1_5MWpersqkm_capacity](https://github.com/user-attachments/assets/e566095c-4ac6-4b04-8a76-967bb1d97560)
- 180 GW - 1.5 cap_per_sqkm
total potential in Germany: 242.4 GW
total installed onshore capacity 180 GW
![180GW_1_5MWpersqkm_capacity](https://github.com/user-attachments/assets/4fa53537-fe4e-4bcd-964b-a2ea5105445c)
- 115 GW - 1.25 cap_per_sqkm
total potential in Germany: 202.0 GW
total installed onshore capacity 130 GW
![115GW_1_25MWpersqkm_capacity](https://github.com/user-attachments/assets/08d506dd-f1c8-4c36-b089-6ee0f811d6f8)
A Flächenziel for each bus region or different regions was investigated in a [closed PR](https://github.com/PyPSA/pypsa-ariadne/pull/290) but did not lead to the desired behavior. 

The config of a minimum target of 160 GW in the main and plus scenarios together with 1.4 cap_per_sqkm is chosen, since the 160 GW are a political target for 2040 and there is a installed capacity of > 20 GW in Southern Germany. A high resolution run for 2045 also shows a total installed capacity of 161 GW which means the minimum constraint is non binding.

Before asking for a review for this PR make sure to complete the following checklist:

- [x] Workflow with target rule `ariadne_all` completes without errors
- [ ] The logic of `export_ariadne_variables` has been adapted to the changes
_not applicable_
- [x] One or several figures that validate the changes in the PR have been posted as a comment
- [x] A brief description of the changes has been added to `Changelog.md`
- [x] The latest `main` has been merged into the PR
- [x] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
