### PR TITLE
Correct reporting of CAPEX / OPEX

### DIFF
--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -400,15 +400,19 @@ def add_system_cost_rows(n):
             )
 
         df["FOM"] = df["capital_cost"] - df["annuity"]
+        # Special case offwind, because it includes the connection
+        if component == "generators":
+            df.loc[
+                df.carrier.str.contains("offwind"),
+                "FOM",
+            ] = 0.023185 * df.loc[
+                df.carrier.str.contains("offwind"),
+                "overnight_cost",
+            ]
         if df["FOM"].min() < 0:
             logger.info(df["FOM"].min())
             logger.error(f"Capital cost is smaller than annuity for {component}")
             # n.links.query("carrier=='DC' and index.str.startswith('DC')")[["carrier","annuity","capital_cost","lifetime","FOM","build_year"]].sort_values("FOM")
-
-        marginal_cost = 0
-        if component != "lines":
-            marginal_cost = df["marginal_cost"]
-        df["OPEX"] = marginal_cost + df["FOM"]
 
 
 """

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -510,9 +510,6 @@ def get_capacity_additions_nstat(n, region):
     return _get_capacities(n, region, _f, cap_string="Capacity Additions Nstat|")
 
 
-
-
-
 def _get_capacities(n, region, cap_func, cap_string="Capacity|"):
 
     kwargs = {

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -405,10 +405,13 @@ def add_system_cost_rows(n):
             df.loc[
                 df.carrier.str.contains("offwind"),
                 "FOM",
-            ] = 0.023185 * df.loc[
-                df.carrier.str.contains("offwind"),
-                "overnight_cost",
-            ]
+            ] = (
+                0.023185
+                * df.loc[
+                    df.carrier.str.contains("offwind"),
+                    "overnight_cost",
+                ]
+            )
         if df["FOM"].min() < 0:
             logger.info(df["FOM"].min())
             logger.error(f"Capital cost is smaller than annuity for {component}")

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -518,7 +518,9 @@ def get_system_cost(n, region):
         if var_name + "Gas|Transmission" in grid_var.keys():
             var[var_name + "Gas"] += grid_var[var_name + "Gas|Transmission"]
 
-    return pd.concat([invest, grid_invest, capex, fom, grid_capex, opex, grid_opex, grid_fom])
+    return pd.concat(
+        [invest, grid_invest, capex, fom, grid_capex, opex, grid_opex, grid_fom]
+    )
 
 
 def get_installed_capacities(n, region):
@@ -5380,7 +5382,6 @@ if __name__ == "__main__":
         ).rename_axis("country")
         for in_ind_prod in snakemake.input.industrial_production_per_country_tomorrow
     ]
-
 
     # Load data
     _networks = [pypsa.Network(fn) for fn in snakemake.input.networks]

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -449,7 +449,7 @@ def get_system_cost(n, region):
         ),
         cap_string="System Cost|CAPEX|",
     )
-    
+
     # Subtracting all capex of assets built before 2020
     capex -= capex2020
 
@@ -3877,7 +3877,7 @@ def get_discretized_value(value, disc_int, build_threshold=0.3):
 def get_grid_investments(
     n,
     region,
-    scope="all", # all, baseyear, expanded
+    scope="all",  # all, baseyear, expanded
     var_name="Investment|Energy Supply|Electricity|Transmission|",
 ):
     assert scope in ["all", "baseyear", "expanded"]
@@ -3885,14 +3885,19 @@ def get_grid_investments(
     var = pd.Series()
 
     offwind = n.generators.filter(like="offwind", axis=0).filter(like="DE", axis=0)
-    
+
     offwind_capacity = offwind.p_nom_opt
     if scope == "expanded":
         offwind_capacity -= offwind.p_nom
     elif scope == "baseyear":
         # WARNING USING GLOBAL VARIABLE `networks[0]`!!!
         # Subtracting 2020 capacity
-        offwind2020 = networks[0].generators.filter(like="offwind", axis=0).filter(like="DE", axis=0).p_nom
+        offwind2020 = (
+            networks[0]
+            .generators.filter(like="offwind", axis=0)
+            .filter(like="DE", axis=0)
+            .p_nom
+        )
         common_index = offwind.index.intersection(offwind2020.index)
         offwind_capacity[common_index] -= offwind2020[common_index]
     offwind_connection_overnight_cost = (
@@ -4016,9 +4021,13 @@ def get_grid_investments(
 
     dg_capacity = distribution_grid.p_nom_opt.sum()
     if scope == "expanded":
-        dg_capacity -= - distribution_grid[distribution_grid.build_year <= year_pre].p_nom_opt.sum()
+        dg_capacity -= -distribution_grid[
+            distribution_grid.build_year <= year_pre
+        ].p_nom_opt.sum()
     elif scope == "baseyear":
-        dg_capacity -= - distribution_grid[distribution_grid.build_year <= 2020].p_nom_opt.sum()
+        dg_capacity -= -distribution_grid[
+            distribution_grid.build_year <= 2020
+        ].p_nom_opt.sum()
 
     dg_investment = (
         dg_capacity * distribution_grid.overnight_cost.unique().item() * 1e-9
@@ -4041,9 +4050,9 @@ def get_grid_investments(
         new_h2_links = h2_links[
             ((year - 5) < h2_links.build_year) & (h2_links.build_year <= year)
         ]
-    else: # scope is all or baseyear
+    else:  # scope is all or baseyear
         new_h2_links = h2_links.copy()
-        
+
     h2_expansion = new_h2_links.p_nom_opt
     h2_investments = h2_expansion * new_h2_links.overnight_cost * 1e-9
     # International h2_projects are only accounted with domestic_length_factor * costs

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -415,6 +415,8 @@ def add_system_cost_rows(n):
 
     Calculate total investment, CAPEX, and OPEX in the given region.
 """
+
+
 def get_system_cost(n, region):
 
     add_system_cost_rows(n)
@@ -423,7 +425,8 @@ def get_system_cost(n, region):
         n,
         region,
         lambda **kwargs: n.statistics.expanded_capex(
-            **kwargs, cost_attribute="overnight_cost"),
+            **kwargs, cost_attribute="overnight_cost"
+        ),
         cap_string="Investment|Energy Supply|",
     )
 
@@ -440,11 +443,14 @@ def get_system_cost(n, region):
 
     # Assuming 40 years lifetime, 7% discount rate
     grid_capex = pd.Series(
-        data=calculate_annuity(40, 0.07) * 5 * grid_invest.values, # yearly invest for 5 years
+        data=calculate_annuity(40, 0.07)
+        * 5
+        * grid_invest.values,  # yearly invest for 5 years
         index=grid_invest.index.str.replace(
             "Investment|Energy Supply|",
             "System Cost|CAPEX|",
-        ))
+        ),
+    )
 
     FOM = _get_capacities(
         n,
@@ -467,30 +473,26 @@ def get_system_cost(n, region):
 
     # Assuming VOM=0, FOM=2% of Investment
     grid_opex = pd.Series(
-        data=0.02 * 5 * grid_invest.values, # yearly invest for 5 years
+        data=0.02 * 5 * grid_invest.values,  # yearly invest for 5 years
         index=grid_invest.index.str.replace(
             "Investment|Energy Supply|",
             "System Cost|OPEX|",
-        ))
-    
+        ),
+    )
+
     for var, grid_var, var_name in zip(
-        [invest, capex, opex], 
-        [grid_invest, grid_capex, grid_opex], 
-        ["Investment|Energy Supply|", "System Cost|CAPEX|", "System Cost|OPEX|"]):
+        [invest, capex, opex],
+        [grid_invest, grid_capex, grid_opex],
+        ["Investment|Energy Supply|", "System Cost|CAPEX|", "System Cost|OPEX|"],
+    ):
         var[var_name + "Electricity"] += grid_var[
             var_name + "Electricity|Transmission and Distribution"
         ]
-        var[var_name + "Hydrogen"] += grid_var[
-            var_name + "Hydrogen|Transmission"
-        ]
+        var[var_name + "Hydrogen"] += grid_var[var_name + "Hydrogen|Transmission"]
         if var_name + "Gas|Transmission" in grid_var.keys():
-            var[var_name + "Gas"] += grid_var[
-                var_name + "Gas|Transmission"
-            ]
-    
-    return pd.concat([invest, grid_invest, capex, grid_capex, opex, grid_opex])
-    
+            var[var_name + "Gas"] += grid_var[var_name + "Gas|Transmission"]
 
+    return pd.concat([invest, grid_invest, capex, grid_capex, opex, grid_opex])
 
 
 def get_installed_capacities(n, region):
@@ -1079,7 +1081,7 @@ def _get_capacities(n, region, cap_func, cap_string="Capacity|"):
         var = var.div(MW2GW).mul(1e-9).div(5).round(3)  # in bn € / year
     elif cap_string.startswith("System Cost"):
         var = var.div(MW2GW).mul(1e-9).round(3)
-    
+
     return var
 
 
@@ -3961,7 +3963,6 @@ def get_grid_investments(
         var[var_name + "AC"] + var[var_name + "DC"]
     )
     var[var_name + "NEP"] = var[var_name + "AC|NEP"] + var[var_name + "DC|NEP"]
-
 
     distribution_grid = n.links[
         (n.links.carrier == "electricity distribution grid")

--- a/workflow/scripts/export_ariadne_variables.py
+++ b/workflow/scripts/export_ariadne_variables.py
@@ -5167,6 +5167,18 @@ def process_postnetworks(n, n_start, model_year, snakemake, costs):
     #     # The values  in p_nom_opt may already be discretized, here we make sure that
     #     # the same logic is applied to p_nom and p_nom_min
     #     n.links.loc[h2_links, attr] = n.links.loc[h2_links, attr].apply(_h2_lambda)
+    logger.info("Assing average Kernnetz cost to carrier H2 pipeline (Kernnetz)")
+    h2_links_kern = n.links.query("carrier == 'H2 pipeline (Kernnetz))'").index
+    capital_costs = (
+        0.7 * costs.at["H2 (g) pipeline", "fixed"]
+        + 0.3 * costs.at["H2 (g) pipeline repurposed", "fixed"]
+    ) * n.links.loc[h2_links_kern, "length"]
+    overnight_costs = (
+        0.7 * costs.at["H2 (g) pipeline", "investment"]
+        + 0.3 * costs.at["H2 (g) pipeline repurposed", "investment"]
+    ) * n.links.loc[h2_links_kern, "length"]
+    n.links.loc[h2_links_kern, "capital_cost"] = capital_costs
+    n.links.loc[h2_links_kern, "overnight_cost"] = overnight_costs
 
     logger.info("Post-Discretizing DC links")
     _dc_lambda = lambda x: get_discretized_value(

--- a/workflow/scripts/plot_ariadne_report.py
+++ b/workflow/scripts/plot_ariadne_report.py
@@ -1288,7 +1288,7 @@ def plot_elec_map_de(
 ):
 
     m = network.copy()
-    m.mremove("Bus", m.buses[m.buses.x == 0].index)
+    m.remove("Bus", m.buses[m.buses.x == 0].index)
     m.buses.drop(m.buses.index[m.buses.carrier != "AC"], inplace=True)
 
     m_base = base_network.copy()
@@ -1345,11 +1345,14 @@ def plot_elec_map_de(
         (m.links.index.str.startswith("DC") | m.links.index.str.startswith("TYNDP"))
         & ~m.links.reversed
     ].index
+    tprojs_all = m.links.loc[
+        (m.links.index.str.startswith("DC") | m.links.index.str.startswith("TYNDP"))
+    ].index
     links_i = m.links.index[m.links.carrier == "DC"]
-    total_exp_linkw = (m.links.p_nom_opt - m_base.links.p_nom).loc[links_i]
+    total_exp_linkw = (m.links.p_nom_opt - m_base.links.p_nom_min).loc[links_i]
     total_exp_linkw[tprojs] = m.links.p_nom_opt[tprojs]
     total_exp_noStart_linkw = total_exp_linkw.copy()
-    total_exp_noStart_linkw.loc[tprojs] = 0
+    total_exp_noStart_linkw.loc[tprojs_all] = 0
     startnetz_linkw = m.links.p_nom_opt[tprojs]
 
     if expansion_case == "total-expansion":
@@ -1375,7 +1378,7 @@ def plot_elec_map_de(
         bus_colors=tech_colors,
         line_widths=line_widths,
         line_colors=tech_colors["AC"],
-        link_widths=link_widths,
+        link_widths=link_widths.clip(0),
         link_colors=tech_colors["DC"],
     )
 
@@ -1506,8 +1509,8 @@ if __name__ == "__main__":
 
     # Hack the transmission projects
     networks = [
-        process_postnetworks(n.copy(), _networks[0], int(my), snakemake, costs)
-        for n, my in zip(_networks, modelyears)
+        process_postnetworks(n.copy(), _networks[0], int(my), snakemake, c)
+        for n, my, c in zip(_networks, modelyears, costs)
     ]
     del _networks
     ###


### PR DESCRIPTION
n.statistics.capex and .opex do not actually report CAPEX and OPEX but fixed and marginal costs. Here we compute the Capex and Opex from the overnight_cost, lifetime, discount rate and fixed costs in the post networks. In the mid-term this should all be directly available from the PyPSA Network

Before asking for a review for this PR make sure to complete the following checklist:

- [ ] Workflow with target rule `ariadne_all` completes without errors
- [x] The logic of `export_ariadne_variables` has been adapted to the changes
- [ ] One or several figures that validate the changes in the PR have been posted as a comment
- [ ] A brief description of the changes has been added to `Changelog.md`
- [ ] The latest `main` has been merged into the PR
- [ ] The config has a new prefix of the format `YYYYMMDDdescriptive_title`
